### PR TITLE
insensitive model comparisons + readonly errors

### DIFF
--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -8,5 +8,6 @@ except ImportError:
 from .sqlite import SqliteDb
 from .base import DbBase
 from .model import DbType, DbCol, DbTable, DbModel, DbIndex
+from . import errors
 
 __all__ = ["SqliteDb", "MySqlDb", "DbRow", "DbBase", "DbType", "DbCol", "DbTable", "DbModel", "DbIndex"]

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -70,15 +70,15 @@ class DbRow(dict):
         return super().__setitem__(CIKey(key), val)
 
     def _asdict(self):
-        return {k: v for k, v in self.items()}
+        return {k: v for k, v in self.items() if k[0:1] != '__'}
 
     def items(self):
-        return ((str(k), v) for k, v in super().items())
+        return ((str(k), v) for k, v in super().items() if k[0:1] != '__')
 
     def _aslist(self):
         if not self.__vals:
-            self.__vals = list(self.values())
-        return self.__vals
+            self["__vals"] = list(self.values())
+        return self["__vals"]
 
 
 # noinspection PyProtectedMember

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -6,7 +6,7 @@ NOTE: Make sure to close the db handle when you are done.
 import time
 import threading
 import logging
-
+from collections import defaultdict
 from abc import ABC, abstractmethod
 
 from .errors import OperationalError
@@ -99,6 +99,7 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
     reconnect_backoff_factor = 2
     debug_sql = None
     debug_args = None
+    __lock_pool = defaultdict(threading.RLock)
 
     @property
     def timeout(self):
@@ -109,7 +110,7 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
         self.__conn_p = None
         self.__conn_args = args
         self.__conn_kws = kws
-        self.r_lock = threading.RLock()
+        self.r_lock = self.__lock_pool[(args, tuple(sorted((k, v) for k, v in kws.items())))]
         self.__primary_cache = {}
         self.__classes = {}
         self._transaction = 0

--- a/notanorm/errors.py
+++ b/notanorm/errors.py
@@ -25,6 +25,8 @@ class IntegrityError(DbError):
 class DbConnectionError(DbError, ConnectionError):
     pass
 
+class DbReadOnlyError(DbError):
+    pass
 
 class ProgrammingError(DbError):
     pass

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -54,3 +54,10 @@ class DbTable(NamedTuple):
 
 class DbModel(dict):
     """Container of table definitions."""
+
+    def _as_cmp(self):
+        return {k.lower(): v for k, v in self.items()}
+
+    def __eq__(self, other):
+        return self._as_cmp() == other._as_cmp()
+

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -14,6 +14,7 @@ class DbType(Enum):
     FLOAT = "float"
     DOUBLE = "double"
     ANY = "any"
+    BOOLEAN = "bool"
 
 
 class DbCol(NamedTuple):

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -26,12 +26,24 @@ class DbCol(NamedTuple):
     fixed: bool = False             # not varchar
     default: Any = None             # has a default value
 
+    def _as_tup(self):
+        return (self.name.lower(), self.typ, self.autoinc, self.size, self.notnull, self.fixed, self.default)
+
+    def __eq__(self, other):
+        return self._as_tup() == other._as_tup()
+
 
 class DbIndex(NamedTuple):
     """Index definition."""
     fields: Tuple[str, ...]         # list of fields in the index
     unique: bool = False            # has a unique index?
     primary: bool = False           # is the primary key?
+
+    def _as_tup(self):
+        return (tuple(f.lower() for f in self.fields), self.unique, self.primary)
+
+    def __eq__(self, other):
+        return self._as_tup() == other._as_tup()
 
 
 class DbTable(NamedTuple):

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -138,6 +138,7 @@ class SqliteDb(DbBase):
         DbType.INTEGER: "integer",
         DbType.FLOAT: "float",
         DbType.DOUBLE: "double",
+        DbType.BOOLEAN: "boolean",
         DbType.ANY: "",
     }
     _type_map_inverse = {v: k for k, v in _type_map.items()}
@@ -150,6 +151,7 @@ class SqliteDb(DbBase):
         "tinyint": DbType.INTEGER,
         "bigint": DbType.INTEGER,
         "clob": DbType.TEXT,
+        "bool": DbType.BOOLEAN,
     })
 
     @classmethod

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -32,10 +32,22 @@ class SqliteDb(DbBase):
         return exp
 
     def __init__(self, *args, **kws):
+        if "timeout" in kws:
+            self.__timeout = kws["timeout"]
+        else:
+            self.__timeout = super().timeout
         if args[0] == ":memory:":
             # never try to reconnect to memory dbs!
             self.max_reconnect_attempts = 1
         super().__init__(*args, **kws)
+
+    @property
+    def timeout(self):
+        return self.__timeout
+
+    @timeout.setter
+    def timeout(self, val):
+        self.__timeout = val
 
     def __columns(self, table):
         res = self.query("SELECT name, type from sqlite_master")

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -11,6 +11,10 @@ log = logging.getLogger(__name__)
 
 class SqliteDb(DbBase):
     placeholder = "?"
+    use_pooled_locks = True
+
+    def _lock_key(self, *args, **kws):
+        return args[0]
 
     def _begin(self, conn):
         conn.execute("BEGIN IMMEDIATE")

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -21,6 +21,8 @@ class SqliteDb(DbBase):
         if isinstance(exp, sqlite3.OperationalError):
             if "no such table" in str(exp):
                 return err.TableNotFoundError(msg)
+            if "readonly" in str(exp):
+                return err.DbReadOnlyError(msg)
             return err.DbConnectionError(msg)
         if isinstance(exp, sqlite3.IntegrityError):
             return err.IntegrityError(msg)

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -98,7 +98,7 @@ class SqliteDb(DbBase):
             size = int(match[2])
         else:
             try:
-                typ = cls._type_map_inverse[info.type]
+                typ = cls._type_map_inverse[info.type.lower()]
             except KeyError:
                 typ = DbType.ANY
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def long_description():
 
 setup(
     name='notanorm',
-    version='1.1.0',
+    version='1.1.2',
     description='DB wrapper library',
     packages=['notanorm'],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -401,6 +401,9 @@ def test_upsert_thready_one(db_notmem):
     for t in ts:
         t.join()
 
+    assert not failed
+    assert len(db.select("foo")) == mod
+
 
 # for some reqson mysql seems connect in a way that causes multiple object to have the same underlying connection
 # todo: maybe using the native "connector" would enable fixing this

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -83,6 +83,12 @@ def test_db_basic(db):
     db.query("insert into foo (bar) values (%s)" % db.placeholder, "hi")
     assert db.query("select bar from foo")[0].bar == "hi"
 
+def test_db_delete(db):
+    db.query("create table foo (bar text)")
+    db.insert("foo", bar="hi")
+    db.delete("foo", bar="hi")
+    assert not db.select("foo")
+
 
 def test_db_count(db):
     db.query("create table foo (bar text)")
@@ -108,9 +114,23 @@ def test_db_row_obj__dict__(db):
     db.query("create table foo (bar text)")
     db.query("insert into foo (bar) values (%s)" % db.placeholder, "hi")
 
-    assert db.select_one("foo").__dict__ == {"bar": "hi"}
-    assert db.select_one("foo")._asdict() == {"bar": "hi"}
+    ret = db.select_one("foo")
+    assert ret.__dict__ == {"bar": "hi"}
+    assert ret._asdict() == {"bar": "hi"}
 
+
+def test_db_row_obj_case(db):
+    db.query("create table foo (Bar text)")
+    db.query("insert into foo (bar) values (%s)" % db.placeholder, "hi")
+
+    ret = db.select_one("foo")
+    assert ret["bar"] == "hi"
+    assert ret["BAR"] == "hi"
+    assert ret.bar == "hi"
+    assert ret.BaR == "hi"
+    assert "Bar" in list(str(k) for k in ret.keys())
+    assert "bar" not in list(str(k) for k in ret.keys())
+    assert "bar" in ret
 
 def test_db_class(db):
     db.query("create table foo (bar text)")

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -11,6 +11,8 @@ import pytest
 
 from notanorm import SqliteDb, DbRow, DbModel, DbCol, DbType, DbTable, DbIndex, DbBase
 
+import notanorm.errors as err
+
 log = logging.getLogger(__name__)
 
 
@@ -413,3 +415,12 @@ def test_transaction_fail_on_begin(db_notmem: "DbBase", db_name):
         with pytest.raises(sqlite3.OperationalError, match=r".*database.*is locked"):
             with db1.transaction():
                 pass
+
+
+@pytest.mark.db("sqlite")
+def test_readonly_fail(db):
+    db.query("create table foo (bar text)")
+    db.insert("foo", bar="y1")
+    db.query("PRAGMA query_only=ON;")
+    with pytest.raises(err.DbReadOnlyError):
+        db.insert("foo", bar="y2")

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -128,9 +128,33 @@ def test_db_row_obj_case(db):
     assert ret["BAR"] == "hi"
     assert ret.bar == "hi"
     assert ret.BaR == "hi"
-    assert "Bar" in list(str(k) for k in ret.keys())
-    assert "bar" not in list(str(k) for k in ret.keys())
+    assert "Bar" in ret.keys()
+    assert "bar" not in ret.keys()
     assert "bar" in ret
+
+def test_db_row_obj_iter(db):
+    db.query("create table foo (Bar text)")
+    db.query("insert into foo (bar) values (%s)" % db.placeholder, "hi")
+
+    ret = db.select_one("foo")
+    for k in ret:
+        assert k == 'Bar'
+
+    assert 'Bar' in ret
+
+def test_db_row_obj_integer_access(db):
+    db.query("create table foo (a text, b text, c text)")
+    db.insert("foo", a="a", b="b", c="c")
+
+    ret = db.select_one("foo")
+
+    assert ret[0] == "a"
+    assert ret[1] == "b"
+    assert ret[2] == "c"
+
+    assert len(list(ret.keys())) == 3
+    assert len(list(ret.values())) == 3
+    assert len(list(ret.items())) == 3
 
 def test_db_class(db):
     db.query("create table foo (bar text)")

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -27,7 +27,7 @@ def db_sqlite():
 
 @pytest.fixture
 def db_sqlite_notmem(tmp_path):
-    db = SqliteDb(str(tmp_path / "db"), timeout=1)
+    db = SqliteDb(str(tmp_path / "db"))
     yield db
     db.close()
 

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -228,15 +228,15 @@ def test_model_cmp(db):
         ]))
     })
     model2 = DbModel({
-        "foo": DbTable(columns=(
+        "FOO": DbTable(columns=(
             DbCol("autO", typ=DbType.INTEGER, autoinc=True, notnull=True),
         ), indexes=tuple([
             DbIndex(fields=("autO", ), primary=True)
         ]))
     })
 
-    assert model1["foo"].columns[0] == model2["foo"].columns[0]
-    assert model1["foo"].indexes[0] == model2["foo"].indexes[0]
+    assert model1["foo"].columns[0] == model2["FOO"].columns[0]
+    assert model1["foo"].indexes[0] == model2["FOO"].indexes[0]
     assert model1 == model2
 
 


### PR DESCRIPTION
- more thread tests
- model comparisons are case-insensitive
- read-only access raises a dedicated DbError
- timeout sanity
- upsert returns info
- boolean type added for sqlite/mysql