### PR TITLE
no update if vals are empty

### DIFF
--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -141,6 +141,7 @@ class DbTxGuard:
 class DbBase(ABC):                          # pylint: disable=too-many-public-methods, too-many-instance-attributes
     """Abstract base class for database connections."""
     placeholder = '?'
+    default_values = 'default values'
     max_reconnect_attempts = 5
     reconnect_backoff_start = 0.1  # seconds
     reconnect_backoff_factor = 2
@@ -331,7 +332,7 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
             sql += ",".join([self.placeholder for _ in vals.keys()])
             sql += ")"
         else:
-            sql += " default values"
+            sql += " " + self.default_values
 
         return self.query(sql, *vals.values())
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -322,13 +322,16 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
 
         sql = "insert into " + table
 
-        sql += '('
-        sql += ','.join([self.quote_keys(k) for k in vals.keys()])
-        sql += ')'
+        if vals:
+            sql += '('
+            sql += ','.join([self.quote_keys(k) for k in vals.keys()])
+            sql += ')'
 
-        sql += " values ("
-        sql += ",".join([self.placeholder for _ in vals.keys()])
-        sql += ")"
+            sql += " values ("
+            sql += ",".join([self.placeholder for _ in vals.keys()])
+            sql += ")"
+        else:
+            sql += " default values"
 
         return self.query(sql, *vals.values())
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -464,6 +464,10 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
         none_keys = [key for key, val in where.items() if val is None]
         del_all(where, none_keys)
 
+        if not vals:
+            # nothing to update
+            return
+
         sql += ", ".join([self.quote_keys(key) + "=" + self.placeholder for key in vals])
         sql += " where "
         sql += " and ".join([self.quote_keys(key) + "=" + self.placeholder for key in where])

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -14,6 +14,7 @@ import logging as log
 
 class MySqlDb(DbBase):
     placeholder = "%s"
+    default_values = ' () values ()'
 
     def _begin(self, conn):
         conn.cursor().execute("START TRANSACTION")

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -56,12 +56,6 @@ class SqliteDb(DbBase):
     def __columns(self, table):
         res = self.query("SELECT name, type from sqlite_master")
 
-        has_seq = False
-        for tab in res:
-            if tab.name == "sqlite_sequence":
-                has_seq = True
-                break
-
         tinfo = self.query("PRAGMA table_info(" + table + ")")
         if len(tinfo) == 0:
             raise KeyError(f"Table {table} not found in db {self}")
@@ -75,7 +69,7 @@ class SqliteDb(DbBase):
         for col in tinfo:
             col.type = col.type.lower()
             col.autoinc = False
-            if col.type == "integer" and col.pk == 1 and one_pk and has_seq:
+            if col.type == "integer" and col.pk == 1 and one_pk:
                 col.autoinc = True
             cols.append(self.__info_to_model(col))
         return tuple(cols)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def long_description():
 
 setup(
     name='notanorm',
-    version='1.1.6',
+    version='1.1.7',
     description='DB wrapper library',
     packages=['notanorm'],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -241,6 +241,10 @@ def test_db_upsert(db):
     # no-op
     db.update("foo", bar="hi")
 
+def test_db_insert_no_vals(db):
+    db.query("create table foo (bar integer default 1)")
+    db.insert("foo")
+
 
 def test_db_upsert_non_null(db):
     db.query("create table foo (bar varchar(32) not null primary key, baz text, bop text)")

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -235,6 +235,12 @@ def test_db_upsert(db):
     assert db.select("foo", bar="hi")[0].baz == "up"
     assert db.select("foo", bar="lo")[0].baz == "down"
 
+    # no-op
+    db.upsert("foo", bar="hi")
+
+    # no-op
+    db.update("foo", bar="hi")
+
 
 def test_db_upsert_non_null(db):
     db.query("create table foo (bar varchar(32) not null primary key, baz text, bop text)")


### PR DESCRIPTION
upsert(tb, keys-only) should insert, but no-op on update
update(tb, keys-only) should also no-op
also, sqlite "has_seq" didn't work... sqlite merely needs a pk with an integer-only field and it becomes autoinc