### PR TITLE
minor-fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 
 ignore = E501, E722, W504
-exclude = env
+exclude = env/, env-pymysql/, build/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	python -m flake8
 
 test:
-	pytest --cov notanorm -v tests
+	pytest -n 2 --cov notanorm -v tests
 
 test-all:
 	pytest --cov notanorm -v tests --db mysql --db sqlite

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -2,7 +2,7 @@
 set -e
 
 # this tests sqlite, mysqlclient
-#cp ci-my.cnf ~/.my.cnf
+cp ci-my.cnf ~/.my.cnf
 
 python3 -m virtualenv env
 make requirements

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -2,18 +2,31 @@
 set -e
 
 # this tests sqlite, mysqlclient
-cp ci-my.cnf ~/.my.cnf
+#cp ci-my.cnf ~/.my.cnf
 
 python3 -m virtualenv env
-. ./env/bin/activate || . ./env/Scripts/activate
 make requirements
-make lint
-make test-all
 
+# lint + sqlite + mysql in parallel
+make lint &
+
+(
+. ./env/bin/activate || . ./env/Scripts/activate
+make test
+) &
+
+
+(
+# this tests pymysql
+. ./env/bin/activate || . ./env/Scripts/activate
+make test-mysql
 deactivate
 
-# this tests pymysql
 python3 -m virtualenv env-pymysql
 . ./env-pymysql/bin/activate || . ./env-pymysql/Scripts/activate
 make requirements-pymysql
 make test-mysql
+
+) &
+
+wait

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -131,10 +131,12 @@ class DbTxGuard:
     def __exit__(self, exc_type, value, _traceback):
         self.db._transaction -= 1
         if not self.db._transaction:  # pylint: disable=protected-access
-            if exc_type:
-                self.db._rollback(self.db._conn_p)
-            else:
-                self.db._commit(self.db._conn_p)
+            # if the connection dropped... we can't roll back or commit
+            if self.db._conn_p:
+                if exc_type:
+                    self.db._rollback(self.db._conn_p)
+                else:
+                    self.db._commit(self.db._conn_p)
         self.lock.release()
 
 

--- a/notanorm/errors.py
+++ b/notanorm/errors.py
@@ -14,6 +14,10 @@ class TableNotFoundError(SchemaError):
     pass
 
 
+class NoColumnError(SchemaError):
+    pass
+
+
 class OperationalError(DbError):
     pass
 

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -42,7 +42,7 @@ class MySqlDb(DbBase):
                 return err.SchemaError(msg)
             if err_code in (1170, ):
                 return err.OperationalError(msg)
-            return err.DbConnectionError(msg)
+            return err.OperationalError(msg)
         if isinstance(exp, InterfaceError):
             return err.DbConnectionError(msg)
         if isinstance(exp, MySQLdb.IntegrityError):

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -38,6 +38,8 @@ class MySqlDb(DbBase):
         msg = str(exp)
 
         if isinstance(exp, MySQLdb.OperationalError):
+            if err_code in (1054, ):
+                return err.NoColumnError(msg)
             if err_code in (1075, 1212, 1239, 1293):
                 return err.SchemaError(msg)
             if err_code in (1170, ):
@@ -50,6 +52,7 @@ class MySqlDb(DbBase):
         if isinstance(exp, MySQLdb.ProgrammingError):
             if exp.args and exp.args[0] == 1146:
                 return err.TableNotFoundError(exp.args[1])
+            return err.OperationalError(msg)
 
         return exp
 

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -42,8 +42,9 @@ class MySqlDb(DbBase):
                 return err.NoColumnError(msg)
             if err_code in (1075, 1212, 1239, 1293):
                 return err.SchemaError(msg)
-            if err_code in (1170, ):
-                return err.OperationalError(msg)
+            if err_code >= 2000:
+                # client connection issues
+                return err.DbConnectionError(msg)
             return err.OperationalError(msg)
         if isinstance(exp, InterfaceError):
             return err.DbConnectionError(msg)

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -51,7 +51,7 @@ class MySqlDb(DbBase):
         if isinstance(exp, MySQLdb.IntegrityError):
             return err.IntegrityError(msg)
         if isinstance(exp, MySQLdb.ProgrammingError):
-            if exp.args and exp.args[0] == 1146:
+            if err_code == 1146:
                 return err.TableNotFoundError(exp.args[1])
             return err.OperationalError(msg)
 

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -28,7 +28,9 @@ class SqliteDb(DbBase):
                 return err.TableNotFoundError(msg)
             if "readonly" in str(exp):
                 return err.DbReadOnlyError(msg)
-            return err.DbConnectionError(msg)
+            if "no column" in str(exp):
+                return err.NoColumnError(msg)
+            return err.OperationalError(msg)
         if isinstance(exp, sqlite3.IntegrityError):
             return err.IntegrityError(msg)
         if isinstance(exp, sqlite3.ProgrammingError):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytest
 coverage>=5
 pytest-cov
+pytest-xdist
 flake8
 mysqlclient

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -663,7 +663,6 @@ def test_readonly_fail(db):
         db.insert("foo", bar="y2")
 
 
-@pytest.mark.db("sqlite")
 def test_missing_column(db):
     db.query("create table foo (bar text)")
     with pytest.raises(err.NoColumnError):

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -663,6 +663,13 @@ def test_readonly_fail(db):
         db.insert("foo", bar="y2")
 
 
+@pytest.mark.db("sqlite")
+def test_missing_column(db):
+    db.query("create table foo (bar text)")
+    with pytest.raises(err.NoColumnError):
+        db.insert("foo", nocol="y2")
+
+
 def test_timeout_rational(db_notmem):
     db = db_notmem
     assert db.max_reconnect_attempts > 1

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -707,4 +707,3 @@ def test_mysql_op_error(db):
 def test_syntax_error(db):
     with pytest.raises(notanorm.errors.OperationalError):
         db.query("create table fo;o (bar text primary key);")
-


### PR DESCRIPTION
1. if a connection error causes the connection to drop, don't bother trying to roll back (and failing)
2. add a specific error for "missing column" and associated tests