### PR TITLE
_insert_only kw

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ret = db.insert("foo", bar="ho")                   # sqlite autoincrement used
 print(ret.lastrowid)                               # "3"
 
 db.upsert("foo", bar="ho", iv=4)                   # upsert requires a primary key, updates or inserts
-db.upsert("foo", bar="ho", _insert_only={"iv": 4}) # _insert_only values are never used to update rows 
+db.upsert("foo", bar="ho", _insert_only={"iv": 4}) # _insert_only values are never used to update rows
 
 # can update with a where clause, or with an implied one
 db.update("foo", iv=4, bar="up")                   # update, no where clause, inferred from primary key

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ret = db.insert("foo", bar="ho")                   # sqlite autoincrement used
 print(ret.lastrowid)                               # "3"
 
 db.upsert("foo", bar="ho", iv=4)                   # upsert requires a primary key, updates or inserts
+db.upsert("foo", bar="ho", _insert_only={"iv": 4}) # _insert_only values are never used to update rows 
 
 # can update with a where clause, or with an implied one
 db.update("foo", iv=4, bar="up")                   # update, no where clause, inferred from primary key

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -599,8 +599,11 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
             else:
                 self.update_all(table, **vals)
 
-    def upsert(self, table, where=None, **vals):
+    def upsert(self, table, where=None, _insert_only=None, **vals):
         """Select a row, and if present, update it, otherwise insert."""
+
+        # insert only fields
+        _insert_only = _insert_only or {}
 
         if hasattr(self, "_upsert_sql"):
             # _upsert_sql is a function that takes two sql statements and joins them into one
@@ -609,6 +612,7 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
             tmp = vals.copy()
             if where is not None:
                 tmp.update(where)
+            tmp.update(_insert_only)
             ins_sql, in_vals = self._insql(table, **tmp)
 
             # discard vals, remove where clause stuff
@@ -628,6 +632,7 @@ class DbBase(ABC):                          # pylint: disable=too-many-public-me
             if not has:
                 # restore value dict
                 vals.update(where)
+                vals.update(_insert_only)
                 return self.insert(table, **vals)
             else:
                 return self.update(table, where, **vals)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name='notanorm',
-    version='2.6.1',
+    version='2.7.0',
     description='DB wrapper library',
     packages=['notanorm'],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -379,8 +379,18 @@ def test_db_upsert(db_sqlup):
     assert db.select("foo", bar="lo")[0].baz == "all"
     assert db.select("foo", bar="hi")[0].baz == "all"
 
-    # funky upsert!
+    # where clause doen't update, only inserts
     db.upsert("foo", {"bar": "new"}, baz="baznew")
+
+    assert db.select("foo", bar="new")[0].baz == "baznew"
+
+    db.upsert("foo", {"bar": "new"}, _insert_only={"baz": "bazdef"})
+
+    assert db.select("foo", bar="new")[0].baz == "baznew"
+
+    db.upsert("foo", {"bar": "n2"}, _insert_only={"baz":"i2"})
+
+    assert db.select("foo", bar="n2")[0].baz == "i2"
 
 
 def test_db_insert_no_vals(db):

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -391,9 +391,9 @@ def test_db_upsert(db_sqlup):
     db.upsert("foo", bar="n2", baz="uponly", _insert_only={"baz": "i2"})
 
     assert db.select("foo", bar="n2")[0].baz == "i2"
- 
+
     db.upsert("foo", bar="n2", baz="uponly", _insert_only={"baz": "i2"})
- 
+
     assert db.select("foo", bar="n2")[0].baz == "uponly"
 
 

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -388,9 +388,13 @@ def test_db_upsert(db_sqlup):
 
     assert db.select("foo", bar="new")[0].baz == "baznew"
 
-    db.upsert("foo", {"bar": "n2"}, _insert_only={"baz": "i2"})
+    db.upsert("foo", bar="n2", baz="uponly", _insert_only={"baz": "i2"})
 
     assert db.select("foo", bar="n2")[0].baz == "i2"
+    
+    db.upsert("foo", bar="n2", baz="uponly", _insert_only={"baz": "i2"})
+    
+    assert db.select("foo", bar="n2")[0].baz == "uponly"
 
 
 def test_db_insert_no_vals(db):

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -391,9 +391,9 @@ def test_db_upsert(db_sqlup):
     db.upsert("foo", bar="n2", baz="uponly", _insert_only={"baz": "i2"})
 
     assert db.select("foo", bar="n2")[0].baz == "i2"
-    
+ 
     db.upsert("foo", bar="n2", baz="uponly", _insert_only={"baz": "i2"})
-    
+ 
     assert db.select("foo", bar="n2")[0].baz == "uponly"
 
 

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -388,7 +388,7 @@ def test_db_upsert(db_sqlup):
 
     assert db.select("foo", bar="new")[0].baz == "baznew"
 
-    db.upsert("foo", {"bar": "n2"}, _insert_only={"baz":"i2"})
+    db.upsert("foo", {"bar": "n2"}, _insert_only={"baz": "i2"})
 
     assert db.select("foo", bar="n2")[0].baz == "i2"
 


### PR DESCRIPTION
allow keys in upsert to be "insert only" ... where they only affect the insert portion of a query