### PR TITLE
no double-close

### DIFF
--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -399,13 +399,15 @@ class DbBase(
 
         with self.r_lock:
             try:
+                done = False
                 fetch = self.execute(sql, tuple(args))
                 rows = fetch.fetchall() if fetch else []
+                done = True
             except Exception as ex:
                 log.debug("sql %s, error %s", sql, repr(ex))
                 raise
             finally:
-                if fetch:
+                if not done:
                     fetch.close()
 
         for row in rows:

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -384,6 +384,7 @@ class DbBase(
                     if type(row) is not DbRow:
                         row = DbRow(row)
                 yield row
+            fetch = None
         finally:
             if fetch:
                 fetch.close()

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -407,7 +407,7 @@ class DbBase(
                 log.debug("sql %s, error %s", sql, repr(ex))
                 raise
             finally:
-                if not done:
+                if fetch and not done:
                     fetch.close()
 
         for row in rows:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name='notanorm',
-    version='2.8.2',
+    version='2.8.3',
     description='DB wrapper library',
     packages=['notanorm'],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -977,13 +977,16 @@ def test_no_extra_close(db):
     mok = MagicMock()
 
     def newx(*a):
-        ret = orig(*a)
+        # mock cursor
+        ret = MagicMock()
+        ret.fetchall = lambda: []
+        ret.fetchone = lambda: None
         ret.close = mok
-        return ret
+        return mok
     db.execute = newx
     db.select("foo")
     list(db.select_gen("foo"))
-    mok.assert_not_called()
+    mok.close.assert_not_called()
 
 
 def test_uri_parse():

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -970,19 +970,20 @@ def test_syntax_error(db):
         db.query("create table fo()o (bar text primary key);")
 
 
+@pytest.mark.db("sqlite")
 def test_no_extra_close(db):
     db.query("create table foo (bar integer primary key);")
     db.insert("foo", bar=1)
-    orig = db.execute
-    mok = MagicMock()
 
+    mok = MagicMock()
     def newx(*a):
         # mock cursor
         ret = MagicMock()
         ret.fetchall = lambda: []
         ret.fetchone = lambda: None
         ret.close = mok
-        return mok
+        return ret
+
     db.execute = newx
     db.select("foo")
     list(db.select_gen("foo"))

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -975,6 +975,7 @@ def test_no_extra_close(db):
     db.insert("foo", bar=1)
     orig = db.execute
     mok = MagicMock()
+
     def newx(*a):
         ret = orig(*a)
         ret.close = mok

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -976,6 +976,7 @@ def test_no_extra_close(db):
     db.insert("foo", bar=1)
 
     mok = MagicMock()
+
     def newx(*a):
         # mock cursor
         ret = MagicMock()


### PR DESCRIPTION
some drivers implement close() in a way that can only be called in the middle of a query