### PR TITLE
ddl model stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ db.select("foo", iv=notnaorm.Op(">", 3))
 
 # wipe the table
 db.delete_all("foo")
+
+### cross database ddl management
+
+# this requires: pip install sqlglot
+
+model = notanorm.model_from_ddl("create table foo(bar integer)")
+
+# create tables and indices from the generic model
+db.create_model(model)
+
+# capture sql statements instead of executing them
+with db.capture_sql(execute=False) as cap:
+   ... do some stuff
+
+print(cap)
 ```
 
 ## Database support

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -26,4 +26,5 @@ __all__ = [
     "errors",
     "Op",
     "open_db",
+    "model_from_ddl",
 ]

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -3,15 +3,22 @@
 from .base import DbRow
 
 try:
+    # if you want this, install mysqlclient or pymysql
     from .mysql import MySqlDb
 except ImportError:
     pass
+
 from .sqlite import SqliteDb
 from .base import DbBase, Op
 from .model import DbType, DbCol, DbTable, DbModel, DbIndex
 from . import errors
 from .connparse import open_db
-from .ddl_helper import model_from_ddl
+
+try:
+    # if you want this, install sqlglot
+    from .ddl_helper import model_from_ddl
+except ImportError:
+    pass
 
 __all__ = [
     "SqliteDb",

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -17,7 +17,7 @@ from .connparse import open_db
 try:
     # if you want this, install sqlglot
     from .ddl_helper import model_from_ddl
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     pass
 
 __all__ = [

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -11,6 +11,7 @@ from .base import DbBase, Op
 from .model import DbType, DbCol, DbTable, DbModel, DbIndex
 from . import errors
 from .connparse import open_db
+from .ddl_helper import model_from_ddl
 
 __all__ = [
     "SqliteDb",

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -319,7 +319,7 @@ class DbBase(
         return model
 
     @contextlib.contextmanager
-    def capture_sql(self, execute=False) -> Generator[List[Tuple[str, Tuple[Any, ...]]]]:
+    def capture_sql(self, execute=False) -> Generator[List[Tuple[str, Tuple[Any, ...]]], None, None]:
         self.__capture = True
         self.__capture_exec = execute
         self.__capture_stmts = []

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -313,8 +313,8 @@ class DbBase(
     def simplify_model(model):
         """Override if you want to allow model comparisons.
 
-        For example, if you have a model that defines a fixed-width char, but your db doesn't support
-        fixed-with char, you can
+        For example, if you have a model that defines a fixed-width char, but your db ignores
+        fixed-with chars, you can remove or normalize the fixed-width flag in the model.
         """
         return model
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -357,7 +357,7 @@ class DbBase(
                     cursor = self._cursor(self._conn())
                     if _script:
                         assert not parameters, "Script isn't compatible with parameters"
-                        self._executemany(cursor,  sql)
+                        self._executemany(cursor, sql)
                     else:
                         cursor.execute(sql, parameters)
                     break

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -338,6 +338,10 @@ class DbBase(
     def executescript(self, sql):
         self.execute(sql, _script=True)
 
+    @staticmethod
+    def _executemany(cursor, sql):
+        return cursor.execute(sql)
+
     def execute(self, sql, parameters=(), _script=False):
         with self.r_lock:
             if self.__capture:
@@ -353,7 +357,7 @@ class DbBase(
                     cursor = self._cursor(self._conn())
                     if _script:
                         assert not parameters, "Script isn't compatible with parameters"
-                        cursor.executescript(sql)
+                        self._executemany(cursor,  sql)
                     else:
                         cursor.execute(sql, parameters)
                     break

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -29,6 +29,19 @@ def del_all(mapping, to_remove):
         del mapping[key]
 
 
+class FakeCursor:
+    rowcount = 0
+    lastrowid = 0
+
+    @staticmethod
+    def fetchall():
+        return []
+
+    @staticmethod
+    def close():
+        pass
+
+
 class CIKey(str):
     def __eq__(self, other):
         return other.lower() == self.lower()
@@ -315,7 +328,7 @@ class DbBase(
         with self.r_lock:
             if self.__capture:
                 self.__capture_stmts.append((sql, parameters))
-                return
+                return FakeCursor()
 
             backoff = self.reconnect_backoff_start
             for tries in range(self.max_reconnect_attempts):

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -8,7 +8,7 @@ import threading
 import logging
 from collections import defaultdict
 from abc import ABC, abstractmethod
-from typing import Dict, List, Type, Any, Tuple
+from typing import Dict, List, Type, Any, Tuple, Generator
 
 from .errors import OperationalError, MoreThanOneError, DbClosedError
 from .model import DbModel, DbTable
@@ -319,7 +319,7 @@ class DbBase(
         return model
 
     @contextlib.contextmanager
-    def capture_sql(self, execute=False) -> List[Tuple[str, Tuple[Any, ...]]]:
+    def capture_sql(self, execute=False) -> Generator[List[Tuple[str, Tuple[Any, ...]]]]:
         self.__capture = True
         self.__capture_exec = execute
         self.__capture_stmts = []

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -309,6 +309,15 @@ class DbBase(
             res += sql + ";\n"
         return res
 
+    @staticmethod
+    def simplify_model(model):
+        """Override if you want to allow model comparisons.
+
+        For example, if you have a model that defines a fixed-width char, but your db doesn't support
+        fixed-with char, you can
+        """
+        return model
+
     @contextlib.contextmanager
     def capture_sql(self, execute=False) -> List[Tuple[str, Tuple[Any, ...]]]:
         self.__capture = True

--- a/notanorm/ddh_helper.py
+++ b/notanorm/ddh_helper.py
@@ -1,0 +1,102 @@
+from collections import defaultdict
+
+import sqlglot
+from sqlglot import parse, exp
+
+from .model import DbType, DbCol, DbTable, DbIndex, DbModel
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class DDLHelper:
+    TYPE_MAP = {
+        exp.DataType.Type.INT: DbType.INTEGER,
+        exp.DataType.Type.BIGINT: DbType.INTEGER,
+        exp.DataType.Type.BOOLEAN: DbType.BOOLEAN,
+        exp.DataType.Type.BINARY: DbType.BLOB,
+        exp.DataType.Type.VARCHAR: DbType.TEXT,
+        exp.DataType.Type.TEXT: DbType.TEXT,
+        exp.DataType.Type.VARIANT: DbType.ANY,
+        exp.DataType.Type.DECIMAL: DbType.DOUBLE,
+        exp.DataType.Type.DOUBLE: DbType.DOUBLE,
+        exp.DataType.Type.FLOAT: DbType.FLOAT
+    }
+
+    def __init__(self, ddl, *dialects):
+        if not dialects:
+            dialects = ("sqlite", "mysql")
+
+        last_x = None
+
+        for dialect in dialects:
+            try:
+                res = parse(ddl, read=dialect)
+                self.ddl = res
+                break
+            except sqlglot.ParseError as ex:
+                last_x = ex
+
+        if last_x:
+            raise last_x
+
+    def __columns(self, ent):
+        cols = []
+        for col in ent.find_all(exp.ColumnDef):
+            dbcol, is_prim = self.__info_to_model(col)
+            if is_prim:
+                self.primary = dbcol
+            cols.append(dbcol)
+        return tuple(cols)
+
+    @staticmethod
+    def __info_to_index(index):
+        primary = index.find(exp.PrimaryKeyColumnConstraint)
+        unique = index.args.get("unique")
+        tab = index.args["this"].args["table"]
+        cols = index.args["this"].args["columns"]
+        field_names = [ent.name for ent in cols.find_all(exp.Column)]
+        return DbIndex(fields=tuple(field_names), primary=bool(primary), unique=bool(unique)), tab.name
+
+    @classmethod
+    def __info_to_model(cls, info):
+        typ = info.find(exp.DataType)
+        typ = cls.TYPE_MAP[typ.this]
+        notnull = info.find(exp.NotNullColumnConstraint)
+        autoinc = info.find(exp.AutoIncrementColumnConstraint)
+        is_primary = info.find(exp.PrimaryKeyColumnConstraint)
+        default = info.find(exp.DefaultColumnConstraint)
+        if default:
+            default = default.find(exp.Literal)
+            if default.is_string:
+                default = "'" + str(default) + "'"
+            else:
+                default = str(default)
+        size = 0
+        fixed = False
+        return DbCol(name=info.name, typ=typ, notnull=bool(notnull),
+                     default=default, autoinc=bool(autoinc),
+                     size=size, fixed=fixed), is_primary
+
+    def model(self):
+        """Get generic db model: dict of tables, each a dict of rows, each with type, unique, autoinc, primary."""
+        model = DbModel()
+        tabs = {}
+        indxs = defaultdict(lambda: [])
+        for ent in self.ddl:
+            tab = ent.find(exp.Table)
+            assert tab, f"unknonwn ddl entry {ent}"
+            idx = ent.find(exp.Index)
+            if not idx:
+                tabs[tab.name] = self.__columns(ent)
+            else:
+                idx, tab_name = self.__info_to_index(ent)
+                indxs[tab_name].append(idx)
+        if self.primary.name:
+            DbIndex(fields=(self.primary.name,), primary=True, unique=False)
+            indxs[tab_name].append(idx)
+
+        for tab in tabs:
+            model[tab] = DbTable(tabs[tab], set(indxs[tab]))
+        return model

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -123,3 +123,8 @@ class DDLHelper:
             dbcols: Tuple[DbCol, ...] = tabs[tab]
             model[tab] = DbTable(dbcols, set(indxs[tab]))
         return model
+
+
+def model_from_ddl(ddl, dialect="mysql"):
+    """Convert indexes and create statements to internal model, without needing a database connection."""
+    return DDLHelper(ddl, dialect).model()

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -4,7 +4,7 @@ from typing import Tuple, Dict, List
 import sqlglot
 from sqlglot import parse, exp
 
-from .model import DbType, DbCol, DbIndex, DbTable, DbModel
+from .model import DbType, DbCol, DbIndex, DbTable, DbModel, ExplicitNone
 
 import logging
 
@@ -34,7 +34,7 @@ class DDLHelper:
 
     def __init__(self, ddl, *dialects):
         if not dialects:
-            dialects = ("sqlite", "mysql")
+            dialects = ("mysql", "sqlite")
 
         last_x = None
 
@@ -97,7 +97,7 @@ class DDLHelper:
         if default:
             lit = default.find(exp.Literal)
             if default.find(exp.Null):
-                default = None
+                default = ExplicitNone()
             elif lit.is_string:
                 default = lit.this
             else:
@@ -138,6 +138,6 @@ class DDLHelper:
         return model
 
 
-def model_from_ddl(ddl, dialect="mysql"):
+def model_from_ddl(ddl, *dialects, dialect=None):
     """Convert indexes and create statements to internal model, without needing a database connection."""
-    return DDLHelper(ddl, dialect).model()
+    return DDLHelper(ddl, *dialects).model()

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -23,13 +23,13 @@ class DDLHelper:
         exp.DataType.Type.VARIANT: DbType.ANY,
         exp.DataType.Type.DECIMAL: DbType.DOUBLE,
         exp.DataType.Type.DOUBLE: DbType.DOUBLE,
-        exp.DataType.Type.FLOAT: DbType.FLOAT
+        exp.DataType.Type.FLOAT: DbType.FLOAT,
     }
 
     FIXED_MAP = {
         exp.DataType.Type.CHAR,
-#  todo: add support for varbinary vs binary in sqlglot
-#        exp.DataType.Type.BINARY
+        #  todo: add support for varbinary vs binary in sqlglot
+        #        exp.DataType.Type.BINARY
     }
 
     def __init__(self, ddl, *dialects):
@@ -73,7 +73,12 @@ class DDLHelper:
         tab = index.args["this"].args["table"]
         cols = index.args["this"].args["columns"]
         field_names = [ent.name for ent in cols.find_all(exp.Column)]
-        return DbIndex(fields=tuple(field_names), primary=bool(primary), unique=bool(unique)), tab.name
+        return (
+            DbIndex(
+                fields=tuple(field_names), primary=bool(primary), unique=bool(unique)
+            ),
+            tab.name,
+        )
 
     @classmethod
     def __info_to_model(cls, info) -> Tuple[DbCol, bool]:
@@ -97,9 +102,18 @@ class DDLHelper:
                 default = lit.this
             else:
                 default = str(lit)
-        return DbCol(name=info.name, typ=typ, notnull=bool(notnull),
-                     default=default, autoinc=bool(autoinc),
-                     size=size, fixed=fixed), is_primary
+        return (
+            DbCol(
+                name=info.name,
+                typ=typ,
+                notnull=bool(notnull),
+                default=default,
+                autoinc=bool(autoinc),
+                size=size,
+                fixed=fixed,
+            ),
+            is_primary,
+        )
 
     def model(self):
         """Get generic db model: dict of tables, each a dict of rows, each with type, unique, autoinc, primary."""

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -121,8 +121,6 @@ class DDLHelper:
         is_primary = info.find(exp.PrimaryKeyColumnConstraint)
         default = info.find(exp.DefaultColumnConstraint)
 
-        if is_primary or primary and info.name in primary.fields:
-            notnull = True
         # sqlglot has no dedicated or well-known type for the 32 in VARCHAR(32)
         # so this is from the grammar of types:  VARCHAR(32) results in a "type.kind.args.expressions" tuple
         expr = info.args["kind"].args.get("expressions")

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Tuple, Dict, List
 
 import sqlglot
 from sqlglot import parse, exp
@@ -17,11 +18,16 @@ class DDLHelper:
         exp.DataType.Type.BOOLEAN: DbType.BOOLEAN,
         exp.DataType.Type.BINARY: DbType.BLOB,
         exp.DataType.Type.VARCHAR: DbType.TEXT,
+        exp.DataType.Type.CHAR: DbType.TEXT,
         exp.DataType.Type.TEXT: DbType.TEXT,
         exp.DataType.Type.VARIANT: DbType.ANY,
         exp.DataType.Type.DECIMAL: DbType.DOUBLE,
         exp.DataType.Type.DOUBLE: DbType.DOUBLE,
         exp.DataType.Type.FLOAT: DbType.FLOAT
+    }
+
+    FIXED_MAP = {
+        exp.DataType.Type.CHAR
     }
 
     def __init__(self, ddl, *dialects):
@@ -41,14 +47,15 @@ class DDLHelper:
         if last_x:
             raise last_x
 
-    def __columns(self, ent):
-        cols = []
+    def __columns(self, ent) -> Tuple[Tuple[DbCol, ...], DbCol]:
+        cols: List[DbCol] = []
+        primary = None
         for col in ent.find_all(exp.ColumnDef):
             dbcol, is_prim = self.__info_to_model(col)
             if is_prim:
-                self.primary = dbcol
+                primary = dbcol
             cols.append(dbcol)
-        return tuple(cols)
+        return tuple(cols), primary
 
     @staticmethod
     def __info_to_index(index):
@@ -60,21 +67,25 @@ class DDLHelper:
         return DbIndex(fields=tuple(field_names), primary=bool(primary), unique=bool(unique)), tab.name
 
     @classmethod
-    def __info_to_model(cls, info):
+    def __info_to_model(cls, info) -> Tuple[DbCol, bool]:
         typ = info.find(exp.DataType)
         typ = cls.TYPE_MAP[typ.this]
+        fixed = typ in cls.FIXED_MAP
         notnull = info.find(exp.NotNullColumnConstraint)
         autoinc = info.find(exp.AutoIncrementColumnConstraint)
         is_primary = info.find(exp.PrimaryKeyColumnConstraint)
         default = info.find(exp.DefaultColumnConstraint)
+        expr = info.args["kind"].args.get("expressions")
+        if expr:
+            size = int(expr[0].this)
+        else:
+            size = 0
         if default:
             default = default.find(exp.Literal)
             if default.is_string:
                 default = "'" + str(default) + "'"
             else:
                 default = str(default)
-        size = 0
-        fixed = False
         return DbCol(name=info.name, typ=typ, notnull=bool(notnull),
                      default=default, autoinc=bool(autoinc),
                      size=size, fixed=fixed), is_primary
@@ -82,21 +93,22 @@ class DDLHelper:
     def model(self):
         """Get generic db model: dict of tables, each a dict of rows, each with type, unique, autoinc, primary."""
         model = DbModel()
-        tabs = {}
+        tabs: Dict[str, Tuple[DbCol, ...]] = {}
         indxs = defaultdict(lambda: [])
         for ent in self.ddl:
             tab = ent.find(exp.Table)
             assert tab, f"unknonwn ddl entry {ent}"
             idx = ent.find(exp.Index)
             if not idx:
-                tabs[tab.name] = self.__columns(ent)
+                tabs[tab.name], primary = self.__columns(ent)
+                if primary:
+                    idx = DbIndex(fields=(primary.name,), primary=True, unique=False)
+                    indxs[tab.name].append(idx)
             else:
                 idx, tab_name = self.__info_to_index(ent)
                 indxs[tab_name].append(idx)
-        if self.primary.name:
-            DbIndex(fields=(self.primary.name,), primary=True, unique=False)
-            indxs[tab_name].append(idx)
 
         for tab in tabs:
-            model[tab] = DbTable(tabs[tab], set(indxs[tab]))
+            dbcols: Tuple[DbCol, ...] = tabs[tab]
+            model[tab] = DbTable(dbcols, set(indxs[tab]))
         return model

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -17,6 +17,17 @@ class DbType(Enum):
     BOOLEAN = "bool"
 
 
+class ExplicitNone:
+    def __eq__(self, other):
+        return isinstance(other, ExplicitNone)
+
+    def __str__(self):
+        return str(None)
+
+    def __repr__(self):
+        return repr(None)
+
+
 class DbCol(NamedTuple):
     """Database column definition that should work on all providers."""
     name: str                       # column name

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -53,7 +53,7 @@ class DbIndex(NamedTuple):
 class DbTable(NamedTuple):
     """Table definition."""
     columns: Tuple[DbCol, ...]
-    indexes: Set[DbIndex] = ()
+    indexes: Set[DbIndex] = set()
 
 
 class DbModel(dict):

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -113,6 +113,7 @@ class MySqlDb(DbBase):
     _type_map_inverse.update({
         "integer": DbType.INTEGER,
         "smallint": DbType.INTEGER,
+        "tinyblob": DbType.BLOB,
     })
 
     def create_table(self, name, schema):
@@ -134,7 +135,7 @@ class MySqlDb(DbBase):
                 if col.fixed:
                     typ = "binary"
                 else:
-                    typ = "varbinary"
+                    typ = "blob"
                 typ += '(%s)' % col.size
             else:
                 typ = self._type_map[col.typ]

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -200,6 +200,25 @@ class MySqlDb(DbBase):
 
         return DbTable(columns=tuple(cols), indexes=set(indexes))
 
+    @staticmethod
+    def simplify_model(model: DbModel):
+        model2 = DbModel()
+        primary_fields = []
+        for nam, tab in model.items():
+            for index in tab.indexes:
+                if index.primary:
+                    primary_fields = index.fields
+            cols = []
+            for col in tab.columns:
+                if col.name in primary_fields:
+                    d = col._asdict()
+                    d["notnull"] = True
+                    col = DbCol(*d)
+                cols.append(col)
+            model2[nam] = DbTable(columns=tuple(cols), indexes=tab.indexes)
+
+        return model2
+
     def column_model(self, info, in_primary):
         # depends on specific mysql version, these are display width hints
 

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -17,9 +17,6 @@ from .model import DbType, DbModel, DbTable, DbCol, DbIndex
 from . import errors as err
 import re
 
-import logging as log
-# driver for mysql
-
 
 class MySqlDb(DbBase):
     uri_name = "mysql"
@@ -159,7 +156,6 @@ class MySqlDb(DbBase):
         create = "create table " + name + "("
         create += ",".join(coldefs)
         create += ")"
-        log.error(create)
         self.query(create)
 
         for idx in schema.indexes:

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -135,7 +135,7 @@ class MySqlDb(DbBase):
                 if col.fixed:
                     typ = "binary"
                 else:
-                    typ = "blob"
+                    typ = "varbinary"
                 typ += '(%s)' % col.size
             else:
                 typ = self._type_map[col.typ]

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -202,7 +202,9 @@ class MySqlDb(DbBase):
 
     def column_model(self, info):
         # depends on specific mysql version, these are display width hints
-        if info.type == "int(11)" or info.type == "int":
+
+        if info.type == "int(11)" or info.type == "int":  # pragma: no cover
+            # whether you see this depends on the version of mysql
             info.type = "integer"
         elif info.type == "tinyint(1)":
             info.type = "boolean"

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -243,6 +243,10 @@ class SqliteDb(DbBase):
                 self.execute(icreate)
 
     @staticmethod
+    def _executemany(cursor, sql):
+        cursor.executescript(sql)
+
+    @staticmethod
     def _obj_factory(cursor, row):
         d = DbRow()
         for idx, col in enumerate(cursor.description):

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -134,12 +134,8 @@ class SqliteDb(DbBase):
         match_b = re.match(r"(varbinary|binary)\((\d+)\)", info.type, re.I)
         if match_t:
             typ = DbType.TEXT
-            fixed = match_t[1] == "character"
-            size = int(match_t[2])
         elif match_b:
             typ = DbType.BLOB
-            fixed = match_b[1] == "binary"
-            size = int(match_b[2])
         else:
             try:
                 typ = cls._type_map_inverse[info.type.lower()]

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -194,7 +194,7 @@ class SqliteDb(DbBase):
         if single_primary and single_primary.lower() == col.name.lower():
             coldef += " primary key"
         if col.autoinc:
-            if single_primary.lower() == col.name.lower():
+            if single_primary and single_primary.lower() == col.name.lower():
                 coldef += " autoincrement"
             else:
                 raise err.SchemaError("sqlite only supports autoincrement on integer primary keys")

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -187,22 +187,8 @@ class SqliteDb(DbBase):
 
     @classmethod
     def _column_def(cls, col: DbCol, single_primary: str):
-        coldef = col.name
+        coldef = cls.quote_key(col.name)
         typ = cls._type_map[col.typ]
-        if col.size and col.typ == DbType.TEXT:
-            if col.fixed:
-                typ = "character"
-            else:
-                typ = "varchar"
-            typ += '(%s)' % col.size
-
-        if col.size and col.typ == DbType.BLOB:
-            if col.fixed:
-                typ = "binary"
-            else:
-                typ = "varbinary"
-            typ += '(%s)' % col.size
-
         if typ:
             coldef += " " + typ
         if col.notnull:
@@ -235,15 +221,15 @@ class SqliteDb(DbBase):
         create += ",".join(coldefs)
         create += ")"
         log.info(create)
-        self.query(create)
+        self.execute(create)
         for idx in schema.indexes:
             if not idx.primary:
                 index_name = "ix_" + name + "_" + "_".join(idx.fields)
                 unique = "unique " if idx.unique else ""
-                icreate = "create " + unique + "index " + index_name + " on " + name + " ("
+                icreate = "create " + unique + "index " + self.quote_key(index_name) + " on " + name + " ("
                 icreate += ",".join(idx.fields)
                 icreate += ")"
-                self.query(icreate)
+                self.execute(icreate)
 
     @staticmethod
     def _obj_factory(cursor, row):

--- a/requirements-pymysql.txt
+++ b/requirements-pymysql.txt
@@ -2,4 +2,5 @@ pytest
 coverage>=5
 pytest-cov
 flake8
+sqlglot
 pymysql

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ codecov
 pytest-cov
 pytest-xdist
 flake8
+sqlglot
 mysqlclient

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name='notanorm',
-    version='2.8.3',
+    version='3.0.1',
     description='DB wrapper library',
     packages=['notanorm'],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,120 @@
+import os
+
+import pytest
+
+from notanorm import SqliteDb
+
+PYTEST_REG = False
+
+
+@pytest.fixture
+def db_sqlite():
+    db = SqliteDb(":memory:")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def db_sqlite_noup():
+    class SqliteDbNoUp(SqliteDb):
+        uri_name = None
+
+        @property
+        def _upsert_sql(self, **_):
+            raise AttributeError
+
+    db = SqliteDbNoUp(":memory:")
+
+    assert not hasattr(db, "_upsert_sql")
+
+    yield db
+
+    db.close()
+
+
+@pytest.fixture
+def db_mysql_noup():
+    from notanorm import MySqlDb
+
+    class MySqlDbNoUp(MySqlDb):
+        uri_name = None
+
+        @property
+        def _upsert_sql(self):
+            raise AttributeError
+
+    db = get_mysql_db(MySqlDbNoUp)
+
+    assert not hasattr(db, "_upsert_sql")
+
+    yield db
+
+    db.close()
+
+
+@pytest.fixture
+def db_sqlite_notmem(tmp_path):
+    db = SqliteDb(str(tmp_path / "db"))
+    yield db
+    db.close()
+
+
+def get_mysql_db(typ):
+    db = typ(read_default_file=os.path.expanduser("~/.my.cnf"), user="root")
+    db.query("DROP DATABASE IF EXISTS test_db")
+    db.query("CREATE DATABASE test_db")
+    db.query("USE test_db")
+
+    return typ(read_default_file=os.path.expanduser("~/.my.cnf"), db="test_db", user="root")
+
+
+def cleanup_mysql_db(db):
+    db._DbBase__closed = False
+    db.query("SET SESSION TRANSACTION READ WRITE;")
+    db.query("DROP DATABASE test_db")
+    db.close()
+
+
+@pytest.fixture
+def db_mysql():
+    from notanorm import MySqlDb
+
+    db = get_mysql_db(MySqlDb)
+    yield db
+    cleanup_mysql_db(db)
+
+
+@pytest.fixture
+def db_mysql_notmem(db_mysql):
+    yield db_mysql
+
+
+@pytest.fixture(name="db")
+def db_fixture(request, db_name):
+    yield request.getfixturevalue("db_" + db_name)
+
+
+@pytest.fixture(name="db_sqlup", params=["", "_noup"])
+def db_sqlup_fixture(request, db_name):
+    yield request.getfixturevalue("db_" + db_name + request.param)
+
+
+@pytest.fixture(name="db_notmem")
+def db_notmem_fixture(request, db_name):
+    yield request.getfixturevalue("db_" + db_name + "_notmem")
+
+
+def pytest_generate_tests(metafunc):
+    """Converts user-argument --db to fixture parameters."""
+
+    global PYTEST_REG  # pylint: disable=global-statement
+    if not PYTEST_REG:
+        if any(db in metafunc.fixturenames for db in ("db", "db_notmem", "db_sqlup")):
+            db_names = metafunc.config.getoption("db", [])
+            db_names = db_names or ["sqlite"]
+            for mark in metafunc.definition.own_markers:
+                if mark.name == "db":
+                    db_names = set(mark.args).intersection(set(db_names))
+                    break
+            db_names = sorted(db_names)  # xdist compat
+            metafunc.parametrize("db_name", db_names, scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,12 +60,12 @@ def db_sqlite_notmem(tmp_path):
 
 
 def get_mysql_db(typ):
-    db = typ(read_default_file=os.path.expanduser("~/.my.cnf"), user="root")
+    db = typ(read_default_file=os.path.expanduser("~/.my.cnf"))
     db.query("DROP DATABASE IF EXISTS test_db")
     db.query("CREATE DATABASE test_db")
     db.query("USE test_db")
 
-    return typ(read_default_file=os.path.expanduser("~/.my.cnf"), db="test_db", user="root")
+    return typ(read_default_file=os.path.expanduser("~/.my.cnf"), db="test_db")
 
 
 def cleanup_mysql_db(db):

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -58,3 +58,18 @@ def test_model_ddl_cap(db):
     extracted = model_from_ddl(ddl, db.uri_name)
 
     assert extracted == captured_model1
+
+
+def test_multi_key():
+    mod = model_from_ddl("create table foo (bar integer, baz integer, primary key (bar, baz))")
+    assert mod["foo"].indexes == {DbIndex(("bar", "baz"), primary=True), }
+
+
+def test_primary_key():
+    mod = model_from_ddl("create table foo (bar integer primary key, baz integer)")
+    assert mod["foo"].indexes == {DbIndex(("bar", ), primary=True), }
+
+
+def test_autoinc():
+    mod = model_from_ddl("create table foo (bar integer auto_increment)")
+    assert mod["foo"].columns == (DbCol("bar", DbType.INTEGER, autoinc=True),)

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -101,6 +101,13 @@ def test_default_bool():
     assert mod["foo"].columns == (DbCol("bar", DbType.BOOLEAN, default=True),)
 
 
+def test_not_null_pk():
+    create = "CREATE TABLE a (id INTEGER, dd TEXT, PRIMARY KEY(id));"
+    mod = model_from_ddl(create)
+    assert mod["a"].columns == (DbCol("id", DbType.INTEGER, notnull=True), DbCol("dd", DbType.TEXT))
+    assert mod["a"].indexes == {DbIndex(("id",), primary=True)}
+
+
 def test_default_str():
     mod = model_from_ddl("create table foo (bar text default 'txt')")
     assert mod["foo"].columns == (DbCol("bar", DbType.TEXT, default='txt'),)

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,7 +1,6 @@
 import sys
 import logging
 import pytest
-import sqlglot.errors
 
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 import notanorm.errors as err
@@ -13,6 +12,8 @@ if tuple(sys.version_info[0: 2]) <= (3, 6):
     pytest.skip("sqlglot requires python 3.7 or greateer", allow_module_level=True)
 
 
+# has to come below the version check above
+import sqlglot.errors  # noqa
 from notanorm.ddl_helper import model_from_ddl  # noqa
 
 

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -2,6 +2,7 @@ import sys
 import logging
 import pytest
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
+import notanorm.errors as err
 
 log = logging.getLogger(__name__)
 
@@ -73,3 +74,10 @@ def test_primary_key():
 def test_autoinc():
     mod = model_from_ddl("create table foo (bar integer auto_increment)")
     assert mod["foo"].columns == (DbCol("bar", DbType.INTEGER, autoinc=True),)
+
+
+def test_err_autoinc(db):
+    # for now, this restriction applies to all db's.   could move it to sqlite only, but needs testing
+    model = model_from_ddl("create table foo (bar integer auto_increment, baz integer auto_increment)")
+    with pytest.raises(err.SchemaError):
+        db.create_model(model)

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -5,6 +5,8 @@ from notanorm.ddl_helper import model_from_ddl
 
 log = logging.getLogger(__name__)
 
+if tuple(sys.version_info[0:2]) <= (3,6):
+  pytest.skip("sqlglot requires python 3.7 or greateer")
 
 def test_model_ddl_cap(db):
     # creating a model using sqlite results in a model that generally works across other db's

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 import sqlglot.errors
 
-import notanorm.errors
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 import notanorm.errors as err
 from notanorm.model import ExplicitNone

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -6,7 +6,7 @@ from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 log = logging.getLogger(__name__)
 
 if tuple(sys.version_info[0: 2]) <= (3, 6):
-    pytest.skip("sqlglot requires python 3.7 or greateer")
+    pytest.skip("sqlglot requires python 3.7 or greateer", allow_module_level=True)
 
 
 from notanorm.ddl_helper import model_from_ddl  # noqa

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,13 +1,15 @@
 import sys
 import logging
+import pytest
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 
 from notanorm.ddl_helper import model_from_ddl
 
 log = logging.getLogger(__name__)
 
-if tuple(sys.version_info[0:2]) <= (3,6):
-  pytest.skip("sqlglot requires python 3.7 or greateer")
+if tuple(sys.version_info[0: 2]) <= (3, 6):
+    pytest.skip("sqlglot requires python 3.7 or greateer")
+
 
 def test_model_ddl_cap(db):
     # creating a model using sqlite results in a model that generally works across other db's

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -49,9 +49,7 @@ def test_model_ddl_cap(db):
 
     # ddl / create + model are the same
     ddl = db.ddl_from_model(model)
-    for ent in ddl.split(";"):
-        if ent.strip():
-            db.execute(ent)
+    db.executescript(ddl)
     captured_model1 = db.model()
 
     db.execute("drop table foo")
@@ -92,7 +90,7 @@ def test_sqlite_only():
 
 def test_primary_key_auto():
     mod = model_from_ddl("create table cars(id integer auto_increment primary key, gas_level double default 1.0);", "mysql")
-    assert mod["cars"].columns == (DbCol("id", DbType.INTEGER, autoinc=True), DbCol("gas_level", DbType.DOUBLE, default='1.0'))
+    assert mod["cars"].columns == (DbCol("id", DbType.INTEGER, autoinc=True, notnull=True), DbCol("gas_level", DbType.DOUBLE, default='1.0'))
     assert mod["cars"].indexes == {DbIndex(("id",), primary=True), }
 
 

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -3,12 +3,13 @@ import logging
 import pytest
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 
-from notanorm.ddl_helper import model_from_ddl
-
 log = logging.getLogger(__name__)
 
 if tuple(sys.version_info[0: 2]) <= (3, 6):
     pytest.skip("sqlglot requires python 3.7 or greateer")
+
+
+from notanorm.ddl_helper import model_from_ddl  # noqa
 
 
 def test_model_ddl_cap(db):

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,21 +1,5 @@
-# pylint: disable=missing-docstring, protected-access, unused-argument, too-few-public-methods
-# pylint: disable=import-outside-toplevel, unidiomatic-typecheck
-
 import logging
-import multiprocessing
-import sqlite3
-import threading
-import time
-from multiprocessing.pool import ThreadPool
-
-import pytest
-
-import notanorm.errors
-from notanorm import SqliteDb, DbRow, DbModel, DbCol, DbType, DbTable, DbIndex, DbBase
-from notanorm.connparse import parse_db_uri
-
-import notanorm.errors as err
-from notanorm.connparse import open_db
+from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 
 from notanorm.ddl_helper import DDLHelper
 
@@ -37,7 +21,6 @@ def test_model_ddl_cap(db):
                         default="4",
                     ),
                     DbCol("blob", typ=DbType.BLOB),
-                    DbCol("blob3", typ=DbType.BLOB, size=3, fixed=True),
                     DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
                     DbCol("tex", typ=DbType.TEXT, notnull=True),
                     DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
@@ -68,48 +51,4 @@ def test_model_ddl_cap(db):
 
     extracted = DDLHelper(ddl, db.uri_name).model()
 
-    assert not model_diff(extracted, captured_model1)
-
-
-def model_diff(a: DbModel, b: DbModel):
-    diff = []
-
-    for tab, coldef in a.items():
-        coldef: DbTable
-        if not b.get(tab):
-            diff.append(("<", {tab}))
-            continue
-
-        bcols: DbTable = b.get(tab)
-        for i, acol in enumerate(coldef.columns):
-            if i >= len(bcols.columns):
-                diff.append(("<", {tab: acol.name}))
-                continue
-
-            if acol != bcols.columns[i]:
-                diff.append(("!", {tab: acol.name, "<": acol, ">": bcols.columns[i]}))
-
-        for i, bcol in enumerate(bcols.columns):
-            if i >= len(bcols.columns):
-                diff.append((">", {tab: bcol.name}))
-                continue
-
-        bcols: DbTable = b.get(tab)
-        for adex in coldef.indexes:
-            if adex not in bcols.indexes:
-                diff.append(("<", {tab: adex}))
-                continue
-
-        for bdex in bcols.indexes:
-            if bdex not in coldef.indexes:
-                diff.append((">", {tab: bdex}))
-                continue
-
-    for tab, coldef in b.items():
-        if not a.get(tab):
-            diff.append((">", {tab}))
-
-    return diff
-
-
-
+    assert extracted == captured_model1

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -23,7 +23,7 @@ def test_model_ddl_cap(db):
         {
             "foo": DbTable(
                 columns=(
-                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True),
                     DbCol(
                         "inty",
                         typ=DbType.INTEGER,
@@ -90,7 +90,7 @@ def test_sqlite_only():
 
 def test_primary_key_auto():
     mod = model_from_ddl("create table cars(id integer auto_increment primary key, gas_level double default 1.0);", "mysql")
-    assert mod["cars"].columns == (DbCol("id", DbType.INTEGER, autoinc=True, notnull=True), DbCol("gas_level", DbType.DOUBLE, default='1.0'))
+    assert mod["cars"].columns == (DbCol("id", DbType.INTEGER, autoinc=True, notnull=False), DbCol("gas_level", DbType.DOUBLE, default='1.0'))
     assert mod["cars"].indexes == {DbIndex(("id",), primary=True), }
 
 
@@ -101,6 +101,13 @@ def test_default_bool():
 
 def test_not_null_pk():
     create = "CREATE TABLE a (id INTEGER, dd TEXT, PRIMARY KEY(id));"
+    mod = model_from_ddl(create)
+    assert mod["a"].columns == (DbCol("id", DbType.INTEGER, notnull=False), DbCol("dd", DbType.TEXT))
+    assert mod["a"].indexes == {DbIndex(("id",), primary=True)}
+
+
+def test_explicit_not_null_pk():
+    create = "CREATE TABLE a (id INTEGER NOT NULL, dd TEXT, PRIMARY KEY(id));"
     mod = model_from_ddl(create)
     assert mod["a"].columns == (DbCol("id", DbType.INTEGER, notnull=True), DbCol("dd", DbType.TEXT))
     assert mod["a"].indexes == {DbIndex(("id",), primary=True)}

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,7 +1,7 @@
 import logging
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 
-from notanorm.ddl_helper import DDLHelper, model_from_ddl
+from notanorm.ddl_helper import model_from_ddl
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -76,13 +76,34 @@ def test_primary_key():
 
 
 def test_autoinc():
-    mod = model_from_ddl("create table foo (bar integer auto_increment)")
+    mod = model_from_ddl("create table foo (bar integer auto_increment)", "mysql")
     assert mod["foo"].columns == (DbCol("bar", DbType.INTEGER, autoinc=True),)
 
 
 def test_default_none():
     mod = model_from_ddl("create table foo (bar text default null)")
     assert mod["foo"].columns == (DbCol("bar", DbType.TEXT, default=ExplicitNone()),)
+
+
+def test_sqlite_only():
+    mod = model_from_ddl("create table foo (bar default 1)")
+    assert mod["foo"].columns == (DbCol("bar", DbType.ANY, default="1"),)
+
+
+def test_primary_key_auto():
+    mod = model_from_ddl("create table cars(id integer auto_increment primary key, gas_level double default 1.0);", "mysql")
+    assert mod["cars"].columns == (DbCol("id", DbType.INTEGER, autoinc=True), DbCol("gas_level", DbType.DOUBLE, default='1.0'))
+    assert mod["cars"].indexes == {DbIndex(("id",), primary=True), }
+
+
+def test_default_bool():
+    mod = model_from_ddl("create table foo (bar boolean default TRUE)")
+    assert mod["foo"].columns == (DbCol("bar", DbType.BOOLEAN, default=True),)
+
+
+def test_default_str():
+    mod = model_from_ddl("create table foo (bar text default 'txt')")
+    assert mod["foo"].columns == (DbCol("bar", DbType.TEXT, default='txt'),)
 
 
 def test_err_autoinc(db):

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,7 +1,7 @@
 import logging
 from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
 
-from notanorm.ddl_helper import DDLHelper
+from notanorm.ddl_helper import DDLHelper, model_from_ddl
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +49,6 @@ def test_model_ddl_cap(db):
     captured_model2 = db.model()
     assert captured_model1 == captured_model2
 
-    extracted = DDLHelper(ddl, db.uri_name).model()
+    extracted = model_from_ddl(ddl, db.uri_name)
 
     assert extracted == captured_model1

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,0 +1,119 @@
+# pylint: disable=missing-docstring, protected-access, unused-argument, too-few-public-methods
+# pylint: disable=import-outside-toplevel, unidiomatic-typecheck
+
+import logging
+import multiprocessing
+import sqlite3
+import threading
+import time
+from multiprocessing.pool import ThreadPool
+
+import pytest
+
+import notanorm.errors
+from notanorm import SqliteDb, DbRow, DbModel, DbCol, DbType, DbTable, DbIndex, DbBase
+from notanorm.connparse import parse_db_uri
+
+import notanorm.errors as err
+from notanorm.connparse import open_db
+
+from notanorm.ddh_helper import DDLHelper
+
+log = logging.getLogger(__name__)
+
+# noinspection PyUnresolvedReferences
+from .test_notanorm import db_fixture, db_sqlite
+
+@pytest.fixture
+def db_name():
+    return "sqlite"
+
+
+def test_model_ddl_cap(db):
+    # creating a model using sqlite results in a model that generally works across other db's
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                    DbCol(
+                        "inty",
+                        typ=DbType.INTEGER,
+                        autoinc=False,
+                        notnull=True,
+                        default="4",
+                    ),
+                    DbCol("blob", typ=DbType.BLOB),
+                    DbCol("blob3", typ=DbType.BLOB, size=3, fixed=True),
+                    DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
+                    DbCol("tex", typ=DbType.TEXT, notnull=True),
+                    DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
+                    DbCol("siz3", typ=DbType.TEXT, size=3, fixed=True),
+                    DbCol("flt", typ=DbType.FLOAT, default="1.1"),
+                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
+                ),
+                indexes={
+                    DbIndex(fields=("auto",), primary=True),
+                    DbIndex(fields=("flt",), unique=True),
+                },
+            )
+        }
+    )
+
+    # ddl / create + model are the same
+    ddl = db.ddl_from_model(model)
+    for ent in ddl.split(";"):
+        db.execute(ent)
+    db2 = SqliteDb(":memory:")
+    db2.create_model(model)
+    captured_model1 = db.model()
+    captured_model2 = db2.model()
+    assert captured_model1 == captured_model2
+
+    extracted = DDLHelper(ddl, "sqlite").model()
+
+    assert not model_diff(extracted, captured_model1)
+
+
+def model_diff(a: DbModel, b: DbModel):
+    diff = []
+
+    for tab, coldef in a.items():
+        coldef: DbTable
+        if not b.get(tab):
+            diff.append(("<", {tab}))
+            continue
+
+        bcols: DbTable = b.get(tab)
+        for i, acol in enumerate(coldef.columns):
+            if i >= len(bcols.columns):
+                diff.append(("<", {tab: acol.name}))
+                continue
+
+            if acol != bcols.columns[i]:
+                diff.append(("!", {tab: acol.name}))
+
+        for i, bcol in enumerate(bcols.columns):
+            if i >= len(bcols.columns):
+                diff.append((">", {tab: bcol.name}))
+                continue
+
+        bcols: DbTable = b.get(tab)
+        for adex in coldef.indexes:
+            if adex not in bcols.indexes:
+                diff.append(("<", {tab: adex}))
+                continue
+
+        for bdex in bcols.indexes:
+            if bdex not in coldef.indexes:
+                diff.append((">", {tab: bdex}))
+                continue
+
+    for tab, coldef in b.items():
+        if not a.get(tab):
+            diff.append((">", {tab}))
+
+    return diff
+
+
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -113,6 +113,23 @@ def test_model_preserve_types(db):
     assert db.simplify_model(check) == db.simplify_model(model)
 
 
+def test_model_primary_key(db):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(DbCol("vtex", typ=DbType.TEXT, size=8),),
+                indexes={DbIndex(("vtex",), primary=True)}
+            )
+        }
+    )
+    db.create_model(model)
+    check = db.model()
+    # simplify model is needed, since many db's will quietly default the column to not null
+    # and that's ok
+    # so we "simplify" by forcing all primary keys to not-null
+    assert db.simplify_model(check) == db.simplify_model(model)
+
+
 def test_model_create_nopk(db):
     model = DbModel(
         {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -105,11 +105,10 @@ def test_model_preserve_types(db):
         {
             "foo": DbTable(
                 columns=(DbCol("vtex", typ=DbType.TEXT, size=3, notnull=True), DbCol("vbin", typ=DbType.BLOB, size=2)),
-                indexes={DbIndex(fields=("vtex",), primary=False)},
             )
         }
     )
-    db.create_model(model)
+    db.execute("create table foo (vtex varchar(3) not null, vbin varbinary(2))")
     check = db.model()
     assert db.simplify_model(check) == db.simplify_model(model)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,166 @@
+# pylint: disable=missing-docstring, protected-access, unused-argument, too-few-public-methods
+# pylint: disable=import-outside-toplevel, unidiomatic-typecheck
+
+import logging
+
+from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
+
+log = logging.getLogger(__name__)
+
+
+def test_model_create(db):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                    DbCol("blob", typ=DbType.BLOB),
+                    DbCol("bool", typ=DbType.BOOLEAN),
+                    DbCol("blob3", typ=DbType.BLOB, size=3, fixed=True),
+                    DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
+                    DbCol("tex", typ=DbType.TEXT, notnull=True),
+                    DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
+                    DbCol("siz3", typ=DbType.TEXT, size=3, fixed=True),
+                    DbCol("flt", typ=DbType.FLOAT, default="1.1"),
+                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
+                ),
+                indexes={
+                    DbIndex(fields=("auto",), primary=True),
+                    DbIndex(fields=("flt",), unique=True),
+                },
+            )
+        }
+    )
+    db.create_model(model)
+    check = db.model()
+    assert db.simplify_model(check) == db.simplify_model(model)
+
+
+def test_model_create_composite_pk(db):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(
+                    DbCol("part1", typ=DbType.INTEGER, notnull=True),
+                    DbCol("part2", typ=DbType.BLOB, size=16, notnull=True),
+                    DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
+                    DbCol("tex", typ=DbType.TEXT, notnull=True),
+                    DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
+                    DbCol("siz3", typ=DbType.TEXT, size=3, fixed=True),
+                    DbCol("flt", typ=DbType.FLOAT, default="1.1"),
+                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
+                ),
+                indexes={
+                    DbIndex(fields=("part1", "part2"), primary=True),
+                },
+            )
+        }
+    )
+    db.create_model(model)
+    check = db.model()
+    assert check["foo"].indexes == model["foo"].indexes
+
+
+def test_model_ddl_cross(db):
+    # creating a model using sqlite results in a model that generally works across other db's
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                    DbCol(
+                        "inty",
+                        typ=DbType.INTEGER,
+                        autoinc=False,
+                        notnull=True,
+                        default="4",
+                    ),
+                    DbCol("blob", typ=DbType.BLOB),
+                    DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
+                    DbCol("tex", typ=DbType.TEXT, notnull=True),
+                    DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
+                    DbCol("siz3", typ=DbType.TEXT, size=3, fixed=True),
+                    DbCol("flt", typ=DbType.FLOAT, default="1.1"),
+                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
+                ),
+                indexes={
+                    DbIndex(fields=("auto",), primary=True),
+                    DbIndex(fields=("flt",), unique=True),
+                },
+            )
+        }
+    )
+    db.create_model(model)
+    extracted_model = db.model()
+
+    db.execute("drop table foo")
+
+    db.create_model(extracted_model)
+    check = db.model()
+    assert check == extracted_model
+
+
+def test_model_create_nopk(db):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(DbCol("inty", typ=DbType.INTEGER),),
+                indexes={DbIndex(fields=("inty",), primary=False)},
+            )
+        }
+    )
+    db.create_model(model)
+    check = db.model()
+    assert check == model
+
+
+def test_model_cap(db):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(DbCol("inty", typ=DbType.INTEGER),),
+                indexes={DbIndex(fields=("inty",), primary=False)},
+            )
+        }
+    )
+
+    ddl = db.ddl_from_model(model)
+
+    expect = """
+create table foo("inty" integer);
+create index "ix_foo_inty" on foo ("inty");
+"""
+    if db.uri_name == "sqlite":
+        assert ddl.strip() == expect.strip()
+    else:
+        # vague assertion that we captured stuff
+        assert "create table" in ddl.lower()
+        assert "foo" in ddl
+        assert "inty" in ddl
+
+
+def test_model_cmp(db):
+    model1 = DbModel(
+        {
+            "foo": DbTable(
+                columns=(
+                    DbCol("Auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                ),
+                indexes={DbIndex(fields=("Auto",), primary=True)},
+            )
+        }
+    )
+    model2 = DbModel(
+        {
+            "FOO": DbTable(
+                columns=(
+                    DbCol("autO", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                ),
+                indexes={DbIndex(fields=("autO",), primary=True)},
+            )
+        }
+    )
+
+    assert model1["foo"].columns[0] == model2["FOO"].columns[0]
+    assert model1 == model2
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -100,6 +100,20 @@ def test_model_ddl_cross(db):
     assert check == extracted_model
 
 
+def test_model_preserve_types(db):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(DbCol("vtex", typ=DbType.TEXT, size=3, notnull=True), DbCol("vbin", typ=DbType.BLOB, size=2)),
+                indexes={DbIndex(fields=("vtex",), primary=False)},
+            )
+        }
+    )
+    db.create_model(model)
+    check = db.model()
+    assert db.simplify_model(check) == db.simplify_model(model)
+
+
 def test_model_create_nopk(db):
     model = DbModel(
         {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -163,4 +163,3 @@ def test_model_cmp(db):
 
     assert model1["foo"].columns[0] == model2["FOO"].columns[0]
     assert model1 == model2
-

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -770,3 +770,12 @@ def test_cap_exec(db):
     assert stmts[0] == ("create table foo(inty integer)", ())
     if db.uri_name == "sqlite":
         assert stmts[1] == ('insert into "foo"("inty") values (?)', (4,))
+
+
+def test_exec_script(db):
+    db.executescript("""
+        create table foo (x integer);
+        create table bar (y integer);
+    """)
+    db.insert("foo", x=1)
+    db.insert("bar", y=2)

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -17,7 +17,6 @@ import notanorm.errors
 import notanorm.errors as err
 from notanorm import SqliteDb, DbRow, DbBase
 from notanorm.connparse import open_db, parse_db_uri
-from notanorm.ddl_helper import model_from_ddl
 
 from tests.conftest import cleanup_mysql_db
 
@@ -303,13 +302,6 @@ def test_db_insert_lrid(db):
     db.query("create table foo (bar integer auto_increment primary key)")
     ret = db.insert("foo")
     assert ret.lastrowid
-
-
-def test_err_autoinc(db):
-    # for now, this restriction applies to all db's.   could move it to sqlite only, but needs testing
-    model = model_from_ddl("create table foo (bar integer auto_increment, baz integer auto_increment)")
-    with pytest.raises(err.SchemaError):
-        db.create_model(model)
 
 
 def test_db_upsert_lrid(db):

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -16,8 +16,9 @@ import pytest
 import notanorm.errors
 import notanorm.errors as err
 from notanorm import SqliteDb, DbRow, DbBase
-from notanorm.connparse import open_db
-from notanorm.connparse import parse_db_uri
+from notanorm.connparse import open_db, parse_db_uri
+from notanorm.ddl_helper import model_from_ddl
+
 from tests.conftest import cleanup_mysql_db
 
 log = logging.getLogger(__name__)
@@ -302,6 +303,13 @@ def test_db_insert_lrid(db):
     db.query("create table foo (bar integer auto_increment primary key)")
     ret = db.insert("foo")
     assert ret.lastrowid
+
+
+def test_err_autoinc(db):
+    # for now, this restriction applies to all db's.   could move it to sqlite only, but needs testing
+    model = model_from_ddl("create table foo (bar integer auto_increment, baz integer auto_increment)")
+    with pytest.raises(err.SchemaError):
+        db.create_model(model)
 
 
 def test_db_upsert_lrid(db):

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -1,9 +1,9 @@
 # pylint: disable=missing-docstring, protected-access, unused-argument, too-few-public-methods
 # pylint: disable=import-outside-toplevel, unidiomatic-typecheck
 
+import copy
 import logging
 import multiprocessing
-import copy
 import sqlite3
 import threading
 import time
@@ -14,15 +14,13 @@ from unittest.mock import MagicMock
 import pytest
 
 import notanorm.errors
-from notanorm import SqliteDb, DbRow, DbModel, DbCol, DbType, DbTable, DbIndex, DbBase
-from notanorm.connparse import parse_db_uri
-
 import notanorm.errors as err
+from notanorm import SqliteDb, DbRow, DbBase
 from notanorm.connparse import open_db
+from notanorm.connparse import parse_db_uri
 from tests.conftest import cleanup_mysql_db
 
 log = logging.getLogger(__name__)
-
 
 
 def test_db_basic(db):
@@ -323,163 +321,6 @@ def test_db_upsert_non_null(db):
 
     assert db.select_one("foo").baz == "up"
     assert db.select_one("foo").bop == "keep"
-
-
-def test_model_create(db):
-    model = DbModel(
-        {
-            "foo": DbTable(
-                columns=(
-                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
-                    DbCol("blob", typ=DbType.BLOB),
-                    DbCol("bool", typ=DbType.BOOLEAN),
-                    DbCol("blob3", typ=DbType.BLOB, size=3, fixed=True),
-                    DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
-                    DbCol("tex", typ=DbType.TEXT, notnull=True),
-                    DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
-                    DbCol("siz3", typ=DbType.TEXT, size=3, fixed=True),
-                    DbCol("flt", typ=DbType.FLOAT, default="1.1"),
-                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
-                ),
-                indexes={
-                    DbIndex(fields=("auto",), primary=True),
-                    DbIndex(fields=("flt",), unique=True),
-                },
-            )
-        }
-    )
-    db.create_model(model)
-    check = db.model()
-    assert db.simplify_model(check) == db.simplify_model(model)
-
-
-def test_model_create_composite_pk(db):
-    model = DbModel(
-        {
-            "foo": DbTable(
-                columns=(
-                    DbCol("part1", typ=DbType.INTEGER, notnull=True),
-                    DbCol("part2", typ=DbType.BLOB, size=16, notnull=True),
-                    DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
-                    DbCol("tex", typ=DbType.TEXT, notnull=True),
-                    DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
-                    DbCol("siz3", typ=DbType.TEXT, size=3, fixed=True),
-                    DbCol("flt", typ=DbType.FLOAT, default="1.1"),
-                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
-                ),
-                indexes={
-                    DbIndex(fields=("part1", "part2"), primary=True),
-                },
-            )
-        }
-    )
-    db.create_model(model)
-    check = db.model()
-    assert check["foo"].indexes == model["foo"].indexes
-
-
-def test_model_ddl_cross(db):
-    # creating a model using sqlite results in a model that generally works across other db's
-    model = DbModel(
-        {
-            "foo": DbTable(
-                columns=(
-                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
-                    DbCol(
-                        "inty",
-                        typ=DbType.INTEGER,
-                        autoinc=False,
-                        notnull=True,
-                        default="4",
-                    ),
-                    DbCol("blob", typ=DbType.BLOB),
-                    DbCol("blob4", typ=DbType.BLOB, size=4, fixed=False),
-                    DbCol("tex", typ=DbType.TEXT, notnull=True),
-                    DbCol("siz3v", typ=DbType.TEXT, size=3, fixed=False),
-                    DbCol("siz3", typ=DbType.TEXT, size=3, fixed=True),
-                    DbCol("flt", typ=DbType.FLOAT, default="1.1"),
-                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
-                ),
-                indexes={
-                    DbIndex(fields=("auto",), primary=True),
-                    DbIndex(fields=("flt",), unique=True),
-                },
-            )
-        }
-    )
-    db.create_model(model)
-    extracted_model = db.model()
-
-    db.execute("drop table foo")
-
-    db.create_model(extracted_model)
-    check = db.model()
-    assert check == extracted_model
-
-
-def test_model_create_nopk(db):
-    model = DbModel(
-        {
-            "foo": DbTable(
-                columns=(DbCol("inty", typ=DbType.INTEGER),),
-                indexes={DbIndex(fields=("inty",), primary=False)},
-            )
-        }
-    )
-    db.create_model(model)
-    check = db.model()
-    assert check == model
-
-
-def test_model_cap(db):
-    model = DbModel(
-        {
-            "foo": DbTable(
-                columns=(DbCol("inty", typ=DbType.INTEGER),),
-                indexes={DbIndex(fields=("inty",), primary=False)},
-            )
-        }
-    )
-
-    ddl = db.ddl_from_model(model)
-
-    expect = """
-create table foo(inty integer);
-create index ix_foo_inty on foo (inty);
-"""
-    if db.uri_name == "sqlite":
-        assert ddl.strip() == expect.strip()
-    else:
-        # vague assertion that we captured stuff
-        assert "create table" in ddl.lower()
-        assert "foo" in ddl
-        assert "inty" in ddl
-
-
-def test_model_cmp(db):
-    model1 = DbModel(
-        {
-            "foo": DbTable(
-                columns=(
-                    DbCol("Auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
-                ),
-                indexes={DbIndex(fields=("Auto",), primary=True)},
-            )
-        }
-    )
-    model2 = DbModel(
-        {
-            "FOO": DbTable(
-                columns=(
-                    DbCol("autO", typ=DbType.INTEGER, autoinc=True, notnull=True),
-                ),
-                indexes={DbIndex(fields=("autO",), primary=True)},
-            )
-        }
-    )
-
-    assert model1["foo"].columns[0] == model2["FOO"].columns[0]
-    assert model1 == model2
 
 
 def test_conn_retry(db):

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -4,7 +4,6 @@
 import logging
 import multiprocessing
 import copy
-import os
 import sqlite3
 import threading
 import time
@@ -19,124 +18,10 @@ from notanorm.connparse import parse_db_uri
 
 import notanorm.errors as err
 from notanorm.connparse import open_db
+from tests.conftest import cleanup_mysql_db
 
 log = logging.getLogger(__name__)
 
-
-PYTEST_REG = False
-
-
-@pytest.fixture
-def db_sqlite():
-    db = SqliteDb(":memory:")
-    yield db
-    db.close()
-
-
-@pytest.fixture
-def db_sqlite_noup():
-    class SqliteDbNoUp(SqliteDb):
-        uri_name = None
-
-        @property
-        def _upsert_sql(self):
-            raise AttributeError
-
-    db = SqliteDbNoUp(":memory:")
-
-    assert not hasattr(db, "_upsert_sql")
-
-    yield db
-
-    db.close()
-
-
-@pytest.fixture
-def db_mysql_noup():
-    from notanorm import MySqlDb
-
-    class MySqlDbNoUp(MySqlDb):
-        uri_name = None
-
-        @property
-        def _upsert_sql(self):
-            raise AttributeError
-
-    db = get_mysql_db(MySqlDbNoUp)
-
-    assert not hasattr(db, "_upsert_sql")
-
-    yield db
-
-    db.close()
-
-
-@pytest.fixture
-def db_sqlite_notmem(tmp_path):
-    db = SqliteDb(str(tmp_path / "db"))
-    yield db
-    db.close()
-
-
-def get_mysql_db(typ):
-    db = typ(read_default_file=os.path.expanduser("~/.my.cnf"))
-    db.query("DROP DATABASE IF EXISTS test_db")
-    db.query("CREATE DATABASE test_db")
-    db.query("USE test_db")
-
-    return typ(read_default_file=os.path.expanduser("~/.my.cnf"), db="test_db")
-
-
-def cleanup_mysql_db(db):
-    db._DbBase__closed = False
-    db.query("SET SESSION TRANSACTION READ WRITE;")
-    db.query("DROP DATABASE test_db")
-    db.close()
-
-
-@pytest.fixture
-def db_mysql():
-    from notanorm import MySqlDb
-
-    db = get_mysql_db(MySqlDb)
-    yield db
-    cleanup_mysql_db(db)
-
-
-@pytest.fixture
-def db_mysql_notmem(db_mysql):
-    yield db_mysql
-
-
-@pytest.fixture(name="db")
-def db_fixture(request, db_name):
-    yield request.getfixturevalue("db_" + db_name)
-
-
-@pytest.fixture(name="db_sqlup", params=["", "_noup"])
-def db_sqlup_fixture(request, db_name):
-    yield request.getfixturevalue("db_" + db_name + request.param)
-
-
-@pytest.fixture(name="db_notmem")
-def db_notmem_fixture(request, db_name):
-    yield request.getfixturevalue("db_" + db_name + "_notmem")
-
-
-def pytest_generate_tests(metafunc):
-    """Converts user-argument --db to fixture parameters."""
-
-    global PYTEST_REG  # pylint: disable=global-statement
-    if not PYTEST_REG:
-        if any(db in metafunc.fixturenames for db in ("db", "db_notmem", "db_sqlup")):
-            db_names = metafunc.config.getoption("db", [])
-            db_names = db_names or ["sqlite"]
-            for mark in metafunc.definition.own_markers:
-                if mark.name == "db":
-                    db_names = set(mark.args).intersection(set(db_names))
-                    break
-            db_names = sorted(db_names)  # xdist compat
-            metafunc.parametrize("db_name", db_names, scope="function")
 
 
 def test_db_basic(db):


### PR DESCRIPTION
Adds two functions:

- model_from_ddl: captures model from ddl (good for specifying model without needing to code it up)
- Base.ddl_from_model:  captures sql and generates a ddl from the specified model (usually for tests)
- simplify_model: allows you to compare convert a complex model spec with a simplified version (such as sqlite)

Sqlite no longer captures complex model info (it's always simplified and reflects the real model).  If you were using it for that, switch to `model_from_ddl` instead