### PR TITLE
fix locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ db = SqliteDb(fname)
 # this works too, params turn into kwargs
 db = open_db("sqlite://:memory:")
 
+db.uri      # get my uri
+db.clone()  # make a copy of the db connection
+
 # no special create support, just use a string
 db.query("create table foo (bar text, iv integer primary key)")
 

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -1,5 +1,6 @@
 """Simple db accessor system: not an orm."""
 
+import sys
 from .base import DbRow
 
 try:
@@ -16,9 +17,9 @@ from .connparse import open_db
 
 try:
     # if you want this, install sqlglot
-    from .ddl_helper import model_from_ddl
-except Exception:
-    # requires it to be installed, and requires python > 3.6
+    if tuple(sys.version_info[:2]) > (3, 6):
+        from .ddl_helper import model_from_ddl
+except ImportError:
     pass
 
 __all__ = [

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -19,7 +19,7 @@ try:
     # if you want this, install sqlglot
     if tuple(sys.version_info[:2]) > (3, 6):
         from .ddl_helper import model_from_ddl
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 __all__ = [

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -17,7 +17,8 @@ from .connparse import open_db
 try:
     # if you want this, install sqlglot
     from .ddl_helper import model_from_ddl
-except (ImportError, ModuleNotFoundError):
+except Exception:
+    # requires it to be installed, and requires python > 3.6
     pass
 
 __all__ = [

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -370,8 +370,8 @@ class DbBase(
             cursor = None
 
             try:
-                cursor = self._cursor(self._conn())
                 with self.r_lock:
+                    cursor = self._cursor(self._conn())
                     if _script:
                         assert not parameters, "Script isn't compatible with parameters"
                         self._executemany(cursor, sql)

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -300,11 +300,11 @@ class DbBase(
 
     @property
     def uri(self) -> str:
-        """Uri can be used to create a copy of my connection"""
+        """Uri that represents a copy of my connection"""
         return self.uri_name + ":" + ",".join(str(v) for v in self._conn_args) + ",".join(k + "=" + str(v) for k, v in self._conn_kws.items())
 
     def clone(self) -> T:
-        """Uri can be used to create a copy of my connection"""
+        """Make a copy of my connection"""
         return type(self)(*self._conn_args, **self._conn_kws)
 
     def model(self) -> DbModel:

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -75,7 +75,7 @@ class DDLHelper:
     def __model_from_sqlglot(self, ddl, dialect):
         # sqlglot generic parser
         tmp_ddl = ddl
-        if dialect == "mysql" and not has_varb:
+        if dialect == "mysql" and not has_varb:  # pragma: no cover
             # sqlglot 9 doesn't support varbinary
             tmp_ddl = ddl.replace("varbinary", "binary")
             tmp_ddl = ddl.replace("VARBINARY", "BINARY")

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -11,6 +11,10 @@ import logging
 log = logging.getLogger(__name__)
 
 
+# some support for different sqlglot versions
+has_varb = getattr(exp.DataType.Type, "VARBINARY", None)
+
+
 class DDLHelper:
     # map of sqlglot expression types to internal model types
     TYPE_MAP = {
@@ -27,10 +31,13 @@ class DDLHelper:
         exp.DataType.Type.FLOAT: DbType.FLOAT,
     }
 
+    if has_varb:
+        TYPE_MAP.update({
+            exp.DataType.Type.VARBINARY: DbType.BLOB,
+        })
+
     FIXED_MAP = {
         exp.DataType.Type.CHAR,
-        #  todo: add support for varbinary vs binary in sqlglot
-        #        exp.DataType.Type.BINARY
     }
 
     def __init__(self, ddl, *dialects):

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -67,9 +67,10 @@ class DDLHelper:
     def __model_from_sqlglot(self, ddl, dialect):
         # sqlglot generic parser
         tmp_ddl = ddl
-        if dialect == "mysql":
-            # bug sqlglot doesn't support varbinary
+        if dialect == "mysql" and not has_varb:
+            # sqlglot 9 doesn't support varbinary
             tmp_ddl = ddl.replace("varbinary", "binary")
+            tmp_ddl = ddl.replace("VARBINARY", "BINARY")
         res = parse(tmp_ddl, read=dialect)
         self.__sqlglot = res
         self.dialect = dialect

--- a/notanorm/errors.py
+++ b/notanorm/errors.py
@@ -44,3 +44,7 @@ class ProgrammingError(DbError):
 
 class MoreThanOneError(DbError, AssertionError):
     pass
+
+
+class UnsafeGeneratorError(DbError):
+    pass

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -305,7 +305,7 @@ def test_db_insert_lrid(db):
 
 
 def test_db_upsert_lrid(db):
-    create_and_fill_test_db(db, 0)
+    db.query("create table foo (bar integer auto_increment primary key)")
     ret = db.upsert("foo", bar=1, baz=2)
     assert ret.lastrowid
 

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -305,7 +305,7 @@ def test_db_insert_lrid(db):
 
 
 def test_db_upsert_lrid(db):
-    db.query("create table foo (bar integer auto_increment primary key)")
+    db.query("create table foo (bar integer auto_increment primary key, baz integer)")
     ret = db.upsert("foo", bar=1, baz=2)
     assert ret.lastrowid
 

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -7,7 +7,7 @@ import multiprocessing
 import sqlite3
 import threading
 import time
-from multiprocessing.pool import ThreadPool
+from multiprocessing.pool import ThreadPool, Pool as ProcessPool
 from typing import Generator
 from unittest.mock import MagicMock
 
@@ -779,3 +779,54 @@ def test_exec_script(db):
     """)
     db.insert("foo", x=1)
     db.insert("bar", y=2)
+
+
+def upserty(uri, i):
+    db = open_db(uri)
+    try:
+        db.generator_guard = True
+        for row in db.select_gen("foo"):
+            db.upsert("foo", bar=row.bar, baz=row.baz + 1)
+        # this is ok: we passed
+        return i
+    except err.UnsafeGeneratorError:
+        # this is ok: we created a consistent error
+        return -1
+
+
+def test_generator_proc(db_notmem):
+    db = db_notmem
+
+    uri = db.uri
+    log.debug("using uri" + uri)
+
+    db.query("CREATE table foo (bar integer primary key, baz integer not null)")
+    for ins in range(20):
+        db.insert("foo", bar=ins, baz=0)
+    db.close()
+
+    proc_num = 4
+
+    pool = ProcessPool(processes=proc_num)
+
+    import functools
+    func = functools.partial(upserty, uri)
+
+    expected = list(range(proc_num * 2))
+
+    if db.uri_name == "sqlite":
+        expected = [-1] * proc_num * 2
+
+    assert pool.map(func, range(proc_num * 2)) == expected
+
+
+def test_db_direct_clone(db_notmem):
+    db = db_notmem.clone()
+    db.query("CREATE table foo (bar integer primary key)")
+    db_notmem.insert("foo", bar=1)
+
+
+def test_db_uri_clone(db_notmem):
+    db = open_db(db_notmem.uri)
+    db.query("CREATE table foo (bar integer primary key)")
+    db_notmem.insert("foo", bar=1)


### PR DESCRIPTION
 - added clone/uri features to base to make it easier to write the test
 - move the existing lock inside the exec function, so retries that do happen re-acquire the lock
 - changed insert/update to not bother fetching nothing from the resulting cursor
 - sqlglot version update compat
 - new UnsafeGeneratorError raised if generator_guard is turned on in a sqlite db