### PR TITLE
several fixes for profile throttle stuff

### DIFF
--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -228,10 +228,13 @@ class MySqlDb(DbBase):
                     primary_fields = index.fields
             cols = []
             for col in tab.columns:
+                d = col._asdict()
+                if col.typ == DbType.INTEGER and not col.size:
+                    # defaults to 8 if unspecified
+                    d["size"] = 8
                 if col.name in primary_fields:
-                    d = col._asdict()
                     d["notnull"] = True
-                    col = DbCol(**d)
+                col = DbCol(**d)
                 cols.append(col)
             model2[nam] = DbTable(columns=tuple(cols), indexes=tab.indexes)
 

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -62,6 +62,8 @@ class MySqlDb(DbBase):
         if isinstance(exp, MySQLdb.OperationalError):
             if err_code in (1054, ):
                 return err.NoColumnError(msg)
+            if err_code in (1050, ):
+                return err.TableExistsError(msg)
             if err_code in (1075, 1212, 1239, 1293):   # pragma: no cover
                 # this error is very hard to support and we should probably drop it
                 # it's used as a base class for TableError and other stuff

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -229,7 +229,7 @@ class MySqlDb(DbBase):
                 if col.name in primary_fields:
                     d = col._asdict()
                     d["notnull"] = True
-                    col = DbCol(*d)
+                    col = DbCol(**d)
                 cols.append(col)
             model2[nam] = DbTable(columns=tuple(cols), indexes=tab.indexes)
 

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -68,6 +68,8 @@ class SqliteDb(DbBase):
         if isinstance(exp, sqlite3.OperationalError):
             if "no such table" in str(exp):
                 return err.TableNotFoundError(msg)
+            if "already exists" in str(exp) and "table " in str(exp):
+                return err.TableExistsError(msg)
             if "readonly" in str(exp):
                 return err.DbReadOnlyError(msg)
             if "no column" in str(exp):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name='notanorm',
-    version='3.0.2',
+    version='3.1.0',
     description='DB wrapper library',
     packages=['notanorm'],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -67,15 +67,18 @@ def test_execute_ddl(db: DbBase):
     db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
     assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
 
+
 def test_execute_ddl_skip_exists(db: DbBase):
     db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
     db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
     assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
 
+
 def test_execute_ddl_exists(db: DbBase):
     db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
     with pytest.raises(err.TableExistsError):
         db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql", ignore_existing=False)
+
 
 def test_execute_sqlite(db: DbBase):
     db.execute_ddl("create table foo (bar integer)", "sqlite")

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -2,7 +2,7 @@ import sys
 import logging
 import pytest
 
-from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex
+from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex, DbBase
 import notanorm.errors as err
 from notanorm.model import ExplicitNone
 
@@ -61,6 +61,16 @@ def test_model_ddl_cap(db):
     extracted = model_from_ddl(ddl, db.uri_name)
 
     assert extracted == captured_model1
+
+
+def test_execute_ddl(db: DbBase):
+    db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
+    assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
+
+
+def test_execute_sqlite(db: DbBase):
+    db.execute_ddl("create table foo (bar integer)", "sqlite")
+    assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
 
 
 def test_multi_key():

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -67,6 +67,15 @@ def test_execute_ddl(db: DbBase):
     db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
     assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
 
+def test_execute_ddl_skip_exists(db: DbBase):
+    db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
+    db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
+    assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
+
+def test_execute_ddl_exists(db: DbBase):
+    db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
+    with pytest.raises(err.TableExistsError):
+        db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql", ignore_existing=False)
 
 def test_execute_sqlite(db: DbBase):
     db.execute_ddl("create table foo (bar integer)", "sqlite")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,12 +10,12 @@ from notanorm.errors import SchemaError
 log = logging.getLogger(__name__)
 
 
-def test_model_create(db):
+def test_model_create_many(db):
     model = DbModel(
         {
             "foo": DbTable(
                 columns=(
-                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True, size=4),
                     DbCol("blob", typ=DbType.BLOB),
                     DbCol("bool", typ=DbType.BOOLEAN),
                     DbCol("blob3", typ=DbType.BLOB, size=3, fixed=True),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,7 +15,7 @@ def test_model_create_many(db):
         {
             "foo": DbTable(
                 columns=(
-                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True, size=4),
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
                     DbCol("blob", typ=DbType.BLOB),
                     DbCol("bool", typ=DbType.BOOLEAN),
                     DbCol("blob3", typ=DbType.BLOB, size=3, fixed=True),

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -310,6 +310,12 @@ def test_db_upsert_lrid(db):
     assert ret.lastrowid
 
 
+def test_tab_exists(db):
+    db.query("create table foo (bar integer)")
+    with pytest.raises(err.TableExistsError):
+        db.query("create table foo (bar integer)")
+
+
 def test_db_upsert_non_null(db):
     db.query(
         "create table foo (bar varchar(32) not null primary key, baz text, bop text)"


### PR DESCRIPTION
- fix major bug in simplify model
- execute_ddl new toplevel function does a model conversion and then execute with an implicit "if not exists" all baked in
- TableExistsError tested (was ignored!)