### PR TITLE
fix uri_name for subclasses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
             python: 3.9
             mysql: 8.0
           - os: ubuntu-latest
-            python: 3.6
+            python: 3.7
             mysql: 8.0
           - os: ubuntu-18.04
             python: 3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+    files: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.10.0
     hooks:
     - id: black
-    files: .

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ publish:
 	rm -rf dist
 	python3 setup.py bdist_wheel
 	twine upload dist/*
+
+install-hooks:
+	pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ requirements-pymysql:
 
 lint:
 	python -m flake8
-	python -m black --check
+	python -m black --check .
 
 test:
 	pytest -n 2 --cov notanorm -v tests

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ requirements-pymysql:
 
 lint:
 	python -m flake8
+	python -m black --check
 
 test:
 	pytest -n 2 --cov notanorm -v tests

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
 except Exception:  # pragma: no cover
     # apparently this can fail for weird reasons, not just import errors
     import logging
+
     logging.exception("failed mysql import for unknown reason")
     pass
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -200,7 +200,7 @@ class DbBase(
     def timeout(self):
         # total timeout for connections == geometric sum
         return self.reconnect_backoff_start * (
-            (1 - self.reconnect_backoff_factor**self.max_reconnect_attempts)
+            (1 - self.reconnect_backoff_factor ** self.max_reconnect_attempts)
             / (1 - self.reconnect_backoff_factor)
         )
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -200,7 +200,7 @@ class DbBase(
     def timeout(self):
         # total timeout for connections == geometric sum
         return self.reconnect_backoff_start * (
-            (1 - self.reconnect_backoff_factor ** self.max_reconnect_attempts)
+            (1 - self.reconnect_backoff_factor**self.max_reconnect_attempts)
             / (1 - self.reconnect_backoff_factor)
         )
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -223,9 +223,10 @@ class DbBase(
         self._conn()
 
     def __init_subclass__(cls: "DbBase", **kwargs):
-        if cls.uri_name:
+        if cls.uri_name and cls.uri_name not in cls.__known_drivers:
             cls.__known_drivers[cls.uri_name] = cls
-        cls.__known_drivers[cls.__name__] = cls
+        if cls.__name__ not in cls.__known_drivers:
+            cls.__known_drivers[cls.__name__] = cls
 
     @classmethod
     def get_driver_by_name(cls, name) -> Type["DbBase"]:

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -397,6 +397,8 @@ class DbBase(
         return model
 
     def execute(self, sql: str, parameters=(), _script=False, write=True):
+        self.__debug_sql(sql, parameters)
+
         if self.__capture:
             self.__capture_stmts.append((sql, parameters))
             if not self.__capture_exec:
@@ -507,8 +509,6 @@ class DbBase(
 
     def query(self, sql: str, *args, factory=None):
         """Run sql, pass args, optionally use factory for each row (cols passed as kwargs)"""
-        self.__debug_sql(sql, args)
-
         fetch = None
 
         ret = self.RetList()

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -212,12 +212,6 @@ class DDLHelper:
         default = info.find(exp.DefaultColumnConstraint)
         is_unique = info.find(exp.UniqueColumnConstraint)
 
-        if dialect == "sqlite" and typ == DbType.INTEGER and is_primary:
-            # todo: shift driver-specific ddl logic to drivers!
-            # sqlite dialect autoincrement is always true on integer primary keys
-            # see: https://www.sqlite.org/autoinc.html
-            autoinc = True
-
         # sqlglot has no dedicated or well-known type for the 32 in VARCHAR(32)
         # so this is from the grammar of types:  VARCHAR(32) results in a "type.kind.args.expressions" tuple
         expr = info.args["kind"].args.get("expressions")

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -8,6 +8,7 @@ __all__ = ["DbType", "DbCol", "DbIndex", "DbIndexField", "DbTable", "DbModel"]
 
 class DbType(Enum):
     """Database types that should work on all providers."""
+
     TEXT = "text"
     BLOB = "blob"
     INTEGER = "int"
@@ -30,16 +31,25 @@ class ExplicitNone:
 
 class DbCol(NamedTuple):
     """Database column definition that should work on all providers."""
-    name: str                       # column name
-    typ: DbType                     # column type
-    autoinc: bool = False           # autoincrement (only integer)
-    size: int = 0                   # for certain types, size is available
-    notnull: bool = False           # not null
-    fixed: bool = False             # not varchar
-    default: Any = None             # has a default value
+
+    name: str  # column name
+    typ: DbType  # column type
+    autoinc: bool = False  # autoincrement (only integer)
+    size: int = 0  # for certain types, size is available
+    notnull: bool = False  # not null
+    fixed: bool = False  # not varchar
+    default: Any = None  # has a default value
 
     def _as_tup(self):
-        return (self.name.lower(), self.typ, self.autoinc, self.size, self.notnull, self.fixed, self.default)
+        return (
+            self.name.lower(),
+            self.typ,
+            self.autoinc,
+            self.size,
+            self.notnull,
+            self.fixed,
+            self.default,
+        )
 
     def __eq__(self, other):
         return self._as_tup() == other._as_tup()
@@ -64,9 +74,10 @@ class DbIndexField(NamedTuple):
 
 class DbIndex(NamedTuple):
     """Index definition."""
+
     fields: Tuple[DbIndexField, ...]
-    unique: bool = False            # has a unique index?
-    primary: bool = False           # is the primary key?
+    unique: bool = False  # has a unique index?
+    primary: bool = False  # is the primary key?
 
     def _as_tup(self) -> Tuple[Tuple[DbIndexField, ...], bool, bool]:
         return (self.fields, self.unique, self.primary)
@@ -80,6 +91,7 @@ class DbIndex(NamedTuple):
 
 class DbTable(NamedTuple):
     """Table definition."""
+
     columns: Tuple[DbCol, ...]
     indexes: Set[DbIndex] = set()
 

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -54,8 +54,8 @@ class SqliteDb(DbBase):
                     *setvals,
                 )
 
-    elif sqlite_version >= (3, 24, 0):
-
+    elif sqlite_version >= (3, 24, 0):  # pragma: no cover
+        # python 3.6 support, can remove it some day
         def _upsert_sql(self, table, inssql, insvals, setsql, setvals):
             fds = ",".join(self.primary_fields(table))
             if not setvals:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ coverage>=5
 codecov
 pytest-cov
 pytest-xdist
+black
 flake8
 sqlglot
 mysqlclient
+pre-commit

--- a/setup.py
+++ b/setup.py
@@ -7,29 +7,29 @@ from setuptools import setup
 def long_description():
     """Autogen description from readme."""
     this_directory = path.abspath(path.dirname(__file__))
-    with open(path.join(this_directory, 'README.md')) as readme_f:
+    with open(path.join(this_directory, "README.md")) as readme_f:
         contents = readme_f.read()
         return contents
 
 
 setup(
-    name='notanorm',
-    version='3.2.2',
-    description='DB wrapper library',
-    packages=['notanorm'],
+    name="notanorm",
+    version="3.2.2",
+    description="DB wrapper library",
+    packages=["notanorm"],
     url="https://github.com/AtakamaLLC/notanorm",
     long_description=long_description(),
     long_description_content_type="text/markdown",
-    setup_requires=['wheel'],
+    setup_requires=["wheel"],
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: MacOS',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development',
-        'Topic :: Utilities',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: MacOS",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development",
+        "Topic :: Utilities",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name='notanorm',
-    version='3.2.1',
+    version='3.2.2',
     description='DB wrapper library',
     packages=['notanorm'],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,6 @@ def db_sqlite():
 @pytest.fixture
 def db_sqlite_noup():
     class SqliteDbNoUp(SqliteDb):
-        uri_name = None
-
         @property
         def _upsert_sql(self, **_):
             raise AttributeError
@@ -37,8 +35,6 @@ def db_mysql_noup():
     from notanorm import MySqlDb
 
     class MySqlDbNoUp(MySqlDb):
-        uri_name = None
-
         @property
         def _upsert_sql(self):
             raise AttributeError

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -69,6 +69,13 @@ def test_execute_ddl(db: DbBase):
     assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
 
 
+def test_ddl_sqlite_primary_key_autoinc(db: DbBase):
+    mod = db.execute_ddl("create table foo (bar integer primary key)", "sqlite")
+    assert db.simplify_model(db.model()) == db.simplify_model(mod)
+    assert db.simplify_model(db.model())["foo"].columns[0].typ == DbType.INTEGER
+    assert db.simplify_model(db.model())["foo"].columns[0].autoinc
+
+
 def test_execute_ddl_skip_exists(db: DbBase):
     db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")
     db.execute_ddl("create table foo (bar integer auto_increment primary key)", "mysql")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -78,7 +78,10 @@ def test_model_create_composite_pk(db):
                     DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
                 ),
                 indexes={
-                    DbIndex(fields=(DbIndexField("part1"), DbIndexField("part2")), primary=True),
+                    DbIndex(
+                        fields=(DbIndexField("part1"), DbIndexField("part2")),
+                        primary=True,
+                    ),
                 },
             )
         }
@@ -130,7 +133,10 @@ def test_model_ddl_cross(db):
 def test_model_prefix_index(db: DbBase) -> None:
     model = DbModel(
         foo=DbTable(
-            columns=(DbCol("intk", typ=DbType.INTEGER, size=4), DbCol("tex", typ=DbType.TEXT),),
+            columns=(
+                DbCol("intk", typ=DbType.INTEGER, size=4),
+                DbCol("tex", typ=DbType.TEXT),
+            ),
             indexes={
                 DbIndex(fields=(DbIndexField("tex", prefix_len=4),)),
             },
@@ -153,11 +159,13 @@ def test_model_prefix_index_multi(db: DbBase) -> None:
                 DbCol("tex2", typ=DbType.TEXT),
             ),
             indexes={
-                DbIndex(fields=(
-                    DbIndexField("tex1", prefix_len=4),
-                    DbIndexField("intk"),
-                    DbIndexField("tex2", prefix_len=7),
-                )),
+                DbIndex(
+                    fields=(
+                        DbIndexField("tex1", prefix_len=4),
+                        DbIndexField("intk"),
+                        DbIndexField("tex2", prefix_len=7),
+                    )
+                ),
             },
         ),
     )
@@ -169,7 +177,9 @@ def test_model_prefix_index_multi(db: DbBase) -> None:
     _check_index_prefix_lens(db, model["foo"], check["foo"])
 
 
-def _check_index_prefix_lens(db: DbBase, tbl_expected: DbTable, tbl_actual: DbTable) -> None:
+def _check_index_prefix_lens(
+    db: DbBase, tbl_expected: DbTable, tbl_actual: DbTable
+) -> None:
     if db.uri_name == "sqlite":
         # SQLite doesn't support prefix indices, so we expect that metadata to be dropped
         assert len(tbl_expected.indexes) == 1
@@ -189,7 +199,10 @@ def test_model_preserve_types(db):
     model = DbModel(
         {
             "foo": DbTable(
-                columns=(DbCol("vtex", typ=DbType.TEXT, size=3, notnull=True), DbCol("vbin", typ=DbType.BLOB, size=2)),
+                columns=(
+                    DbCol("vtex", typ=DbType.TEXT, size=3, notnull=True),
+                    DbCol("vbin", typ=DbType.BLOB, size=2),
+                ),
             )
         }
     )
@@ -203,7 +216,7 @@ def test_model_primary_key(db):
         {
             "foo": DbTable(
                 columns=(DbCol("vtex", typ=DbType.TEXT, size=8),),
-                indexes={DbIndex((DbIndexField("vtex"),), primary=True)}
+                indexes={DbIndex((DbIndexField("vtex"),), primary=True)},
             )
         }
     )
@@ -242,7 +255,7 @@ def test_model_create_indexes(db: "DbBase"):
                 ),
                 indexes={
                     DbIndex(fields=(DbIndexField("inty"),), primary=True),
-                    DbIndex(fields=(DbIndexField("vary"),), unique=True)
+                    DbIndex(fields=(DbIndexField("vary"),), unique=True),
                 },
             )
         }
@@ -281,9 +294,7 @@ def test_model_any(db):
     mod = DbModel(
         {
             "foo": DbTable(
-                columns=(
-                    DbCol("any", typ=DbType.ANY),
-                ),
+                columns=(DbCol("any", typ=DbType.ANY),),
             )
         }
     )

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -15,7 +15,7 @@ import pytest
 
 import notanorm.errors
 import notanorm.errors as err
-from notanorm import SqliteDb, DbRow, DbBase
+from notanorm import SqliteDb, DbRow, DbBase, DbType
 from notanorm.connparse import open_db, parse_db_uri
 
 from tests.conftest import cleanup_mysql_db
@@ -737,6 +737,13 @@ def test_no_extra_close(db):
     db.select("foo")
     list(db.select_gen("foo"))
     mok.close.assert_not_called()
+
+
+@pytest.mark.db("sqlite")
+def test_any_col(db):
+    db.query("create table foo (bar whatever primary key);")
+    db.insert("foo", bar=1)
+    assert db.model()["foo"].columns[0].typ == DbType.ANY
 
 
 def test_uri_parse():

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -359,8 +359,6 @@ def test_multi_close(db):
     db.close()
 
     class VeryClose(SqliteDb):
-        uri_name = None
-
         def __init__(self):
             self.close()
 

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -144,6 +144,14 @@ def test_db_select_gen_ex(db):
             pass
 
 
+def test_db_tab_not_found(db):
+    db.query("create table foo (bar integer)")
+    with pytest.raises(notanorm.errors.TableNotFoundError):
+        db.select("foox")
+    with pytest.raises(notanorm.errors.TableNotFoundError):
+        db.execute("drop table foox")
+
+
 def test_db_row_obj_iter(db):
     db.query("create table foo (Bar text)")
     db.query("insert into foo (bar) values (%s)" % db.placeholder, "hi")
@@ -781,16 +789,20 @@ def test_cap_exec(db):
 
 
 def test_exec_script(db):
-    db.executescript("""
+    db.executescript(
+        """
         create table foo (x integer);
         create table bar (y integer);
-    """)
+    """
+    )
     db.insert("foo", x=1)
     db.insert("bar", y=2)
 
 
 def create_and_fill_test_db(db, num, tab="foo"):
-    db.query(f"CREATE table {tab} (bar integer primary key, baz integer not null, cnt integer default 0)")
+    db.query(
+        f"CREATE table {tab} (bar integer primary key, baz integer not null, cnt integer default 0)"
+    )
     for ins in range(num):
         db.insert(tab, bar=ins, baz=0)
 
@@ -878,6 +890,7 @@ def test_generator_proc(db_notmem):
     pool = ProcessPool(processes=proc_num)
 
     import functools
+
     func = functools.partial(upserty, uri)
 
     expected = list(range(proc_num * 2))


### PR DESCRIPTION
 - test integer primary key for sqlite dialect (was untested, but worked fine)
 - uri_name for subclasses should be ok for inheritance, not kill parent driver (just give it a new name!)
 - transition to black
 - test for TableNotFound