### PR TITLE
mysql default to long text

### DIFF
--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -17,7 +17,7 @@ except Exception:  # pragma: no cover
 
 from .sqlite import SqliteDb
 from .base import DbBase, Op, ReconnectionArgs
-from .model import DbType, DbCol, DbTable, DbModel, DbIndex, DbIndexField
+from .model import DbType, DbCol, DbTable, DbModel, DbIndex, DbIndexField, DbColCustomInfo
 from . import errors
 from .connparse import open_db
 
@@ -35,6 +35,7 @@ __all__ = [
     "DbBase",
     "DbType",
     "DbCol",
+    "DbColCustomInfo",
     "DbTable",
     "DbModel",
     "DbIndex",

--- a/notanorm/__init__.py
+++ b/notanorm/__init__.py
@@ -17,7 +17,15 @@ except Exception:  # pragma: no cover
 
 from .sqlite import SqliteDb
 from .base import DbBase, Op, ReconnectionArgs
-from .model import DbType, DbCol, DbTable, DbModel, DbIndex, DbIndexField, DbColCustomInfo
+from .model import (
+    DbType,
+    DbCol,
+    DbTable,
+    DbModel,
+    DbIndex,
+    DbIndexField,
+    DbColCustomInfo,
+)
 from . import errors
 from .connparse import open_db
 

--- a/notanorm/ddl_helper.py
+++ b/notanorm/ddl_helper.py
@@ -3,7 +3,16 @@ from typing import Tuple, Dict, List, Any, Type
 
 from sqlglot import Expression, parse, exp
 
-from .model import DbType, DbCol, DbIndex, DbTable, DbModel, ExplicitNone, DbIndexField, DbColCustomInfo
+from .model import (
+    DbType,
+    DbCol,
+    DbIndex,
+    DbTable,
+    DbModel,
+    ExplicitNone,
+    DbIndexField,
+    DbColCustomInfo,
+)
 from .sqlite import SqliteDb
 from . import errors as err
 
@@ -52,11 +61,11 @@ class DDLHelper:
     FIXED_MAP = {
         exp.DataType.Type.CHAR,
     }
-   
+
     # custom info for weird types and the drivers that might care aboutthem
     CUSTOM_MAP = {
-            ("mysql", exp.DataType.Type.MEDIUMTEXT): DbColCustomInfo("mysql", "medium"), 
-            ("mysql", exp.DataType.Type.TEXT): DbColCustomInfo("mysql", "small"), 
+        ("mysql", exp.DataType.Type.MEDIUMTEXT): DbColCustomInfo("mysql", "medium"),
+        ("mysql", exp.DataType.Type.TEXT): DbColCustomInfo("mysql", "small"),
     }
 
     def __init__(self, ddl, *dialects):

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -3,7 +3,15 @@
 from enum import Enum
 from typing import NamedTuple, Tuple, Any, Set, Dict, Optional
 
-__all__ = ["DbType", "DbCol", "DbIndex", "DbIndexField", "DbTable", "DbModel", "DbColCustomInfo"]
+__all__ = [
+    "DbType",
+    "DbCol",
+    "DbIndex",
+    "DbIndexField",
+    "DbTable",
+    "DbModel",
+    "DbColCustomInfo",
+]
 
 
 class DbType(Enum):

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import NamedTuple, Tuple, Any, Set, Dict, Optional
 
-__all__ = ["DbType", "DbCol", "DbIndex", "DbIndexField", "DbTable", "DbModel"]
+__all__ = ["DbType", "DbCol", "DbIndex", "DbIndexField", "DbTable", "DbModel", "DbColCustomInfo"]
 
 
 class DbType(Enum):
@@ -29,6 +29,11 @@ class ExplicitNone:
         return repr(None)
 
 
+class DbColCustomInfo(NamedTuple):
+    dialect: str  # dialect (usually matches uri_type)
+    info: Any
+
+
 class DbCol(NamedTuple):
     """Database column definition that should work on all providers."""
 
@@ -39,6 +44,7 @@ class DbCol(NamedTuple):
     notnull: bool = False  # not null
     fixed: bool = False  # not varchar
     default: Any = None  # has a default value
+    custom: DbColCustomInfo = None  # dialect-specific column information
 
     def _as_tup(self):
         return (
@@ -49,6 +55,7 @@ class DbCol(NamedTuple):
             self.notnull,
             self.fixed,
             self.default,
+            self.custom,
         )
 
     def __eq__(self, other):

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -1,5 +1,13 @@
 from .base import DbBase, parse_bool
-from .model import DbType, DbModel, DbTable, DbCol, DbIndex, DbIndexField, DbColCustomInfo
+from .model import (
+    DbType,
+    DbModel,
+    DbTable,
+    DbCol,
+    DbIndex,
+    DbIndexField,
+    DbColCustomInfo,
+)
 from . import errors as err
 
 import re
@@ -157,7 +165,10 @@ class MySqlDb(DbBase):
         }
     )
     _int_map = {1: "tinyint", 2: "smallint", 4: "integer", 8: "bigint"}
-    _type_map_custom = {"mediumtext": DbColCustomInfo("mysql", "medium"), "text": DbColCustomInfo("mysql", "small")}
+    _type_map_custom = {
+        "mediumtext": DbColCustomInfo("mysql", "medium"),
+        "text": DbColCustomInfo("mysql", "small"),
+    }
 
     def create_table(self, name, schema: DbTable, ignore_existing=False):
         coldefs = []
@@ -349,7 +360,7 @@ class MySqlDb(DbBase):
             notnull=not autoinc_primary and info.null == "NO",
             default=info.default,
             autoinc=info.extra == "auto_increment",
-            custom=custom
+            custom=custom,
         )
 
         return ret

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -184,7 +184,7 @@ class MySqlDb(DbBase):
                     typ = "mediumtext"
                 elif col.custom.info == "small":
                     typ = "text"
-                else:
+                else:  # pragma: no cover
                     assert False, "unknown custom info"
             elif col.size and col.typ == DbType.TEXT:
                 if col.fixed:

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -280,12 +280,14 @@ class SqliteDb(DbBase):
             new_cols = []
             for coldef in tdef.columns:
                 # sizes & fixed-width specifiers are ignored in sqlite
+                custom = coldef.custom if coldef.custom and coldef.custom.dialect == "sqlite" else None
                 newcol = DbCol(
                     name=coldef.name,
                     typ=coldef.typ,
                     autoinc=coldef.autoinc,
                     notnull=coldef.notnull,
                     default=coldef.default,
+                    custom=custom,
                 )
                 new_cols.append(newcol)
             new_idxes = set()

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -280,7 +280,11 @@ class SqliteDb(DbBase):
             new_cols = []
             for coldef in tdef.columns:
                 # sizes & fixed-width specifiers are ignored in sqlite
-                custom = coldef.custom if coldef.custom and coldef.custom.dialect == "sqlite" else None
+                custom = (
+                    coldef.custom
+                    if coldef.custom and coldef.custom.dialect == "sqlite"
+                    else None
+                )
                 newcol = DbCol(
                     name=coldef.name,
                     typ=coldef.typ,

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -2,7 +2,16 @@ import sys
 import logging
 import pytest
 
-from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex, DbBase, DbIndexField, DbColCustomInfo
+from notanorm import (
+    DbModel,
+    DbCol,
+    DbType,
+    DbTable,
+    DbIndex,
+    DbBase,
+    DbIndexField,
+    DbColCustomInfo,
+)
 import notanorm.errors as err
 from notanorm.model import ExplicitNone
 
@@ -407,5 +416,5 @@ def test_custom_creat(db: "DbBase"):
         assert src_mod == db_mod
     else:
         assert src_mod != db_mod
-    
+
     assert db.simplify_model(src_mod) == db.simplify_model(db_mod)

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -2,7 +2,7 @@ import sys
 import logging
 import pytest
 
-from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex, DbBase, DbIndexField
+from notanorm import DbModel, DbCol, DbType, DbTable, DbIndex, DbBase, DbIndexField, DbColCustomInfo
 import notanorm.errors as err
 from notanorm.model import ExplicitNone
 
@@ -293,7 +293,7 @@ def test_autoinc():
 
 
 def test_default_none():
-    mod = model_from_ddl("create table foo (bar text default null)")
+    mod = model_from_ddl("create table foo (bar longtext default null)")
     assert mod["foo"].columns == (DbCol("bar", DbType.TEXT, default=ExplicitNone()),)
 
 
@@ -322,7 +322,7 @@ def test_default_bool():
 
 
 def test_not_null_pk():
-    create = "CREATE TABLE a (id INTEGER, dd TEXT, PRIMARY KEY(id));"
+    create = "CREATE TABLE a (id INTEGER, dd LONGTEXT, PRIMARY KEY(id));"
     mod = model_from_ddl(create)
     assert mod["a"].columns == (
         DbCol("id", DbType.INTEGER, notnull=False, size=4),
@@ -332,7 +332,7 @@ def test_not_null_pk():
 
 
 def test_explicit_not_null_pk():
-    create = "CREATE TABLE a (id INTEGER NOT NULL, dd TEXT, PRIMARY KEY(id));"
+    create = "CREATE TABLE a (id INTEGER NOT NULL, dd LONGTEXT, PRIMARY KEY(id));"
     mod = model_from_ddl(create)
     assert mod["a"].columns == (
         DbCol("id", DbType.INTEGER, notnull=True, size=4),
@@ -342,7 +342,7 @@ def test_explicit_not_null_pk():
 
 
 def test_unique_col():
-    create = "CREATE TABLE a (id INTEGER NOT NULL, dd TEXT unique);"
+    create = "CREATE TABLE a (id INTEGER NOT NULL, dd LONGTEXT unique);"
     mod = model_from_ddl(create, "mysql")
     assert mod["a"].columns == (
         DbCol("id", DbType.INTEGER, notnull=True, size=4),
@@ -352,7 +352,7 @@ def test_unique_col():
 
 
 def test_default_str():
-    mod = model_from_ddl("create table foo (bar text default 'txt')")
+    mod = model_from_ddl("create table foo (bar longtext default 'txt')")
     assert mod["foo"].columns == (DbCol("bar", DbType.TEXT, default="txt"),)
 
 
@@ -386,3 +386,26 @@ def test_detect_dialect():
 def test_parser_error():
     with pytest.raises(sqlglot.errors.ParseError):
         model_from_ddl("create table foo (bar integer auto_increment, ")
+
+
+def test_custom_type():
+    create = "CREATE TABLE a (st TEXT, mt MEDIUMTEXT, lt LONGTEXT);"
+    mod = model_from_ddl(create, "mysql")
+    assert mod["a"].columns == (
+        DbCol("st", DbType.TEXT, custom=DbColCustomInfo("mysql", "small")),
+        DbCol("mt", DbType.TEXT, custom=DbColCustomInfo("mysql", "medium")),
+        DbCol("lt", DbType.TEXT),
+    )
+
+
+def test_custom_creat(db: "DbBase"):
+    create = "CREATE TABLE a (st TEXT, mt MEDIUMTEXT, lt LONGTEXT);"
+    src_mod = model_from_ddl(create, "mysql")
+    db.create_model(src_mod)
+    db_mod = db.model()
+    if db.uri_name == "mysql":
+        assert src_mod == db_mod
+    else:
+        assert src_mod != db_mod
+    
+    assert db.simplify_model(src_mod) == db.simplify_model(db_mod)


### PR DESCRIPTION
- support for custom dbcolinfo of arbitrary type
- ddl helper shoves custom info, based on dialect
- mysql driver uses the custom info, if present
- simplifiers toss away custom info that's not relevant