### PR TITLE
db table migrate, rename, drop

### DIFF
--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -681,13 +681,16 @@ class DbBase(
         raise RuntimeError("Generic create index not supported")
 
     def drop_index(self, table: str, index: DbIndex):
-        for idx in self.model()[table].indexes:
-            if idx == index:
-                self.drop_index_by_name(table, index.name)
+        self.drop_index_by_name(table, self.get_index_name(table, index))
 
     def drop_index_by_name(self, table: str, index_name):
         sql = "drop index " + self.quote_key(index_name)
         self.execute(sql)
+
+    def get_index_name(self, table: str, index: DbIndex):
+        for idx in self.model()[table].indexes:
+            if idx == index:
+                return idx.name
 
     @classmethod
     def unique_index_name(cls, table, field_names):

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -1193,7 +1193,7 @@ class DbBase(
         return self.execute(sql)
 
     def drop(self, table):
-        """Rename a table"""
+        """Drop a table"""
         sql = "drop table " + self.quote_key(table)
         return self.execute(sql)
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -395,6 +395,7 @@ class DbBase(
     def capture_sql(
         self, execute=False
     ) -> Generator[List[Tuple[str, Tuple[Any, ...]]], None, None]:
+        """Use in a with block to return a list of sql statements and parameters."""
         self.__capture = True
         self.__capture_exec = execute
         self.__capture_stmts = []
@@ -404,13 +405,16 @@ class DbBase(
             self.__capture = False
 
     def create_model(self, model: DbModel, ignore_existing=False):
+        """Given a database model, create all the corresponding tables and indexes."""
         for name, schema in model.items():
             self.create_table(name, schema, ignore_existing)
 
-    def create_table(self, name, schema: DbTable, ignore_existing=False):
+    def create_table(
+        self, name, schema: DbTable, ignore_existing=False
+    ):  # pragma: no cover
         raise RuntimeError("Generic create table not supported")
 
-    def create_indexes(self, name, schema: DbTable):
+    def create_indexes(self, name, schema: DbTable):  # pragma: no cover
         raise RuntimeError("Generic create index not supported")
 
     def drop_index(self, table: str, index: DbIndex):

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -93,7 +93,9 @@ class DbIndex(NamedTuple):
     fields: Tuple[DbIndexField, ...]
     unique: bool = False  # has a unique index?
     primary: bool = False  # is the primary key?
-    ix__name: Optional[str] = None  # only avail when reading from a db model, not a ddl
+
+    # don't use this field, it's internal, but named tuples are weirdly limited
+    ix__name: Optional[str] = None
 
     def _as_tup(self) -> Tuple[Tuple[DbIndexField, ...], bool, bool]:
         return (self.fields, self.unique, self.primary)
@@ -104,8 +106,9 @@ class DbIndex(NamedTuple):
     def __hash__(self):
         return hash(self._as_tup())
 
+    # correct way to access the name
     @property
-    def name(self):
+    def name(self) -> Optional[str]:
         return self.ix__name
 
 

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -93,6 +93,7 @@ class DbIndex(NamedTuple):
     fields: Tuple[DbIndexField, ...]
     unique: bool = False  # has a unique index?
     primary: bool = False  # is the primary key?
+    ix__name: str = None  # only avail when reading from a db model, not a ddl
 
     def _as_tup(self) -> Tuple[Tuple[DbIndexField, ...], bool, bool]:
         return (self.fields, self.unique, self.primary)
@@ -102,6 +103,10 @@ class DbIndex(NamedTuple):
 
     def __hash__(self):
         return hash(self._as_tup())
+
+    @property
+    def name(self):
+        return self.ix__name
 
 
 class DbTable(NamedTuple):

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -93,9 +93,7 @@ class DbIndex(NamedTuple):
     fields: Tuple[DbIndexField, ...]
     unique: bool = False  # has a unique index?
     primary: bool = False  # is the primary key?
-
-    # don't use this field, it's internal, but named tuples are weirdly limited
-    ix__name: Optional[str] = None
+    name: Optional[str] = None  # only set when reading from the db, ignored on creation
 
     def _as_tup(self) -> Tuple[Tuple[DbIndexField, ...], bool, bool]:
         return (self.fields, self.unique, self.primary)
@@ -105,11 +103,6 @@ class DbIndex(NamedTuple):
 
     def __hash__(self):
         return hash(self._as_tup())
-
-    # correct way to access the name
-    @property
-    def name(self) -> Optional[str]:
-        return self.ix__name
 
 
 class DbTable(NamedTuple):

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -104,6 +104,18 @@ class DbIndex(NamedTuple):
     def __hash__(self):
         return hash(self._as_tup())
 
+    @classmethod
+    def from_fields(cls, fields, unique=False, primary=False):
+        assert type(fields) in (tuple, list)
+        return DbIndex(
+            tuple(
+                DbIndexField(*tuple((ent,) if type(ent) is str else ent))
+                for ent in fields
+            ),
+            unique,
+            primary,
+        )
+
 
 class DbTable(NamedTuple):
     """Table definition."""

--- a/notanorm/model.py
+++ b/notanorm/model.py
@@ -93,7 +93,7 @@ class DbIndex(NamedTuple):
     fields: Tuple[DbIndexField, ...]
     unique: bool = False  # has a unique index?
     primary: bool = False  # is the primary key?
-    ix__name: str = None  # only avail when reading from a db model, not a ddl
+    ix__name: Optional[str] = None  # only avail when reading from a db model, not a ddl
 
     def _as_tup(self) -> Tuple[Tuple[DbIndexField, ...], bool, bool]:
         return (self.fields, self.unique, self.primary)

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -279,7 +279,7 @@ class MySqlDb(DbBase):
                     tuple(DbIndexField(**f) for f in fds),
                     primary=primary,
                     unique=unique,
-                    ix__name=name,
+                    name=name,
                 )
             )
 

--- a/notanorm/mysql.py
+++ b/notanorm/mysql.py
@@ -42,6 +42,7 @@ class MySqlDb(DbBase):
 
     placeholder = "%s"
     default_values = " () values ()"
+    max_index_name = 64
 
     def _begin(self, conn):
         conn.cursor().execute("START TRANSACTION")

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -186,7 +186,9 @@ class SqliteDb(DbBase):
         unique = bool(index.unique) and not primary
         field_names = [ent.name for ent in sorted(cols, key=lambda col: col.seqno)]
         fields = tuple(DbIndexField(n) for n in field_names)
-        return DbIndex(fields=fields, primary=primary, unique=unique)
+        return DbIndex(
+            fields=fields, primary=primary, unique=unique, ix__name=index.name
+        )
 
     @classmethod
     def __info_to_model(cls, info):
@@ -332,19 +334,17 @@ class SqliteDb(DbBase):
         log.info(create)
         self.execute(create)
 
-        self.create_indexes(name, schema, ignore_existing)
+        self.create_indexes(name, schema)
 
-    def create_indexes(self, name, schema, ignore_existing=False):
-        ignore = "if not exists " if ignore_existing else ""
+    def create_indexes(self, name, schema):
         for idx in schema.indexes:
             if not idx.primary:
-                index_name = "ix_" + name + "_" + "_".join(f.name for f in idx.fields)
+                index_name = self.unique_index_name(name, (f.name for f in idx.fields))
                 unique = "unique " if idx.unique else ""
                 icreate = (
                     "create "
                     + unique
                     + "index "
-                    + ignore
                     + self.quote_key(index_name)
                     + " on "
                     + name

--- a/notanorm/sqlite.py
+++ b/notanorm/sqlite.py
@@ -186,9 +186,7 @@ class SqliteDb(DbBase):
         unique = bool(index.unique) and not primary
         field_names = [ent.name for ent in sorted(cols, key=lambda col: col.seqno)]
         fields = tuple(DbIndexField(n) for n in field_names)
-        return DbIndex(
-            fields=fields, primary=primary, unique=unique, ix__name=index.name
-        )
+        return DbIndex(fields=fields, primary=primary, unique=unique, name=index.name)
 
     @classmethod
     def __info_to_model(cls, info):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name="notanorm",
-    version="3.4.0",
+    version="3.5.0",
     description="DB wrapper library",
     packages=["notanorm"],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name="notanorm",
-    version="3.3.1",
+    version="3.4.0",
     description="DB wrapper library",
     packages=["notanorm"],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -39,6 +39,22 @@ def test_model_create_many(db: "DbBase"):
     assert db.simplify_model(check) == db.simplify_model(model)
 
 
+def test_model_many_cols(db: "DbBase"):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=tuple(
+                    DbCol("x" + str(i), typ=DbType.INTEGER) for i in range(100)
+                ),
+                indexes={
+                    DbIndex(fields=tuple(DbIndexField("x" + str(i)) for i in range(16)))
+                },
+            )
+        }
+    )
+    db.create_model(model)
+
+
 def test_model_migrate(db: "DbBase"):
     model = DbModel(
         {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring, protected-access, unused-argument, too-few-public-methods
 # pylint: disable=import-outside-toplevel, unidiomatic-typecheck
 
+import re
 import logging
 import pytest
 
@@ -36,6 +37,43 @@ def test_model_create_many(db: "DbBase"):
     db.create_model(model)
     check = db.model()
     assert db.simplify_model(check) == db.simplify_model(model)
+
+
+def test_model_migrate(db: "DbBase"):
+    model = DbModel(
+        {
+            "foo": DbTable(
+                columns=(
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                    DbCol("dbl", typ=DbType.INTEGER, default="2"),
+                ),
+                indexes={
+                    DbIndex(fields=(DbIndexField("auto"),), primary=True),
+                    DbIndex(fields=(DbIndexField("dbl"),), unique=True),
+                },
+            )
+        }
+    )
+    db.create_model(model)
+    db.rename("foo", "foo_old")
+    model2 = DbModel(
+        {
+            "foo": DbTable(
+                columns=(
+                    DbCol("auto", typ=DbType.INTEGER, autoinc=True, notnull=True),
+                    DbCol("dbl", typ=DbType.DOUBLE, default="2.2"),
+                ),
+                indexes={
+                    DbIndex(fields=(DbIndexField("auto"),), primary=True),
+                    DbIndex(fields=(DbIndexField("dbl"),)),
+                },
+            )
+        }
+    )
+    db.create_model(model2)
+    db.drop("foo_old")
+    check = db.model()
+    assert db.simplify_model(check) == db.simplify_model(model2)
 
 
 def test_model_intsize(db):
@@ -277,12 +315,12 @@ def test_model_cap(db):
 
     ddl = db.ddl_from_model(model)
 
-    expect = """
-create table foo("inty" integer);
-create index "ix_foo_inty" on foo ("inty");
+    expect = r"""
+create table foo\("inty" integer\);
+create index "ix_foo_inty_\w+" on foo \("inty"\);
 """
     if db.uri_name == "sqlite":
-        assert ddl.strip() == expect.strip()
+        assert re.match(expect.strip(), ddl.strip())
     else:
         # vague assertion that we captured stuff
         assert "create table" in ddl.lower()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -39,10 +39,25 @@ def test_model_create_many(db: "DbBase"):
     assert db.simplify_model(check) == db.simplify_model(model)
 
 
-def test_model_many_cols(db: "DbBase"):
+def test_model_many_index_cols(db: "DbBase"):
     model = DbModel(
         {
             "foo": DbTable(
+                columns=tuple(
+                    DbCol("x" + str(i), typ=DbType.INTEGER) for i in range(100)
+                ),
+                indexes={
+                    DbIndex(fields=tuple(DbIndexField("x" + str(i)) for i in range(16)))
+                },
+            )
+        }
+    )
+    db.create_model(model)
+
+    verybigtablename = "x" * 60
+    model = DbModel(
+        {
+            verybigtablename: DbTable(
                 columns=tuple(
                     DbCol("x" + str(i), typ=DbType.INTEGER) for i in range(100)
                 ),

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -14,7 +14,7 @@ import pytest
 
 import notanorm.errors
 import notanorm.errors as err
-from notanorm import SqliteDb, DbRow, DbBase, DbType, And, Or, Op
+from notanorm import SqliteDb, DbRow, DbBase, DbType, DbIndex, And, Or, Op, DbIndexField
 from notanorm.connparse import open_db, parse_db_uri
 
 log = logging.getLogger(__name__)
@@ -1253,7 +1253,9 @@ def test_rename_drop(db):
 def test_drop_index(db):
     db.execute("create table foo (bar integer)")
     db.execute("create unique index ix_foo_uk on foo(bar)")
-    idx = db.model()["foo"].indexes.pop()
-    assert idx.name
+    assert db.model()["foo"].indexes.pop().name
+    idx = DbIndex(fields=(DbIndexField("bar"),), unique=True)
+    assert not idx.name
+    assert "ix_foo_uk" == db.get_index_name("foo", idx)
     db.drop_index("foo", idx)
     assert not db.model()["foo"].indexes

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -1255,6 +1255,9 @@ def test_drop_index(db):
     db.execute("create unique index ix_foo_uk on foo(bar)")
     assert db.model()["foo"].indexes.pop().name
     idx = DbIndex(fields=(DbIndexField("bar"),), unique=True)
+    # simplified constructor
+    idx2 = DbIndex.from_fields(["bar"], unique=True)
+    assert idx == idx2
     assert not idx.name
     assert "ix_foo_uk" == db.get_index_name("foo", idx)
     db.drop_index("foo", idx)


### PR DESCRIPTION
db migration

 - rename tables
 - indexes have uuids
 - drop indexes on a table by property match
 - drop tables by name