### PR TITLE
group_by support

### DIFF
--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -968,7 +968,7 @@ class DbBase(
         factory = where.pop("__class", fac) if not is_list(where) else fac
 
         field_map = None
-        if fields is None:
+        if not fields:
             if type(table) in (JoinQ, SubQ):
                 sql += table.field_sql()
             else:

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -223,6 +223,8 @@ class JoinQ(BaseQ):
 
     def resolve_field(self, field: str):
         ret = None
+        if "." in field:
+            return field
         for tab in (self.tab1, self.tab2):
             if field in self.db.get_subq_col_names(tab):
                 if ret is not None:

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -1172,7 +1172,9 @@ class DbBase(
         if not where:
             where = kws
 
-        if type(agg_map_or_str) is str:
+        simple_result = type(agg_map_or_str) is str
+
+        if simple_result:
             agg_map = {"k": agg_map_or_str}
         else:
             agg_map = agg_map_or_str
@@ -1197,11 +1199,11 @@ class DbBase(
                 ret[index] = {}
                 for alias in agg_map:
                     ret[index][alias] = row[alias]
-            if type(agg_map_or_str) is str:
+            if simple_result:
                 ret = {k: v["k"] for k, v in ret.items()}
         else:
             ret = self.query(sql, *vals)[0]
-            if type(agg_map_or_str) is str:
+            if simple_result:
                 ret = ret["k"]
 
         return ret

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -333,6 +333,7 @@ WhereClauseType = Union[QueryDictType, QueryListType]
 WhereKwargsType = Union[QueryValueType, QueryListType]
 LimitArgType = Union[int, Tuple[int, int]]
 GroupByArgType = Union[str, Iterable[str]]
+OrderByArgType = Union[str, Iterable[str]]
 
 
 class And(QueryListType):
@@ -1054,7 +1055,7 @@ class DbBase(
 
         return sql, vals, factory
 
-    def order_by_query(self, _order_by):
+    def order_by_query(self, _order_by: OrderByArgType):
         if isinstance(_order_by, str):
             _order_by = [_order_by]
         order_by_fd = ",".join(_order_by)
@@ -1080,7 +1081,7 @@ class DbBase(
         _where=None,
         *,
         order_by=None,
-        _order_by=None,
+        _order_by: OrderByArgType = None,
         _limit: Optional[LimitArgType] = None,
         _group_by: Optional[GroupByArgType] = None,
         **where: WhereKwargsType,
@@ -1118,7 +1119,7 @@ class DbBase(
         _where=None,
         *,
         order_by=None,
-        _order_by=None,
+        _order_by: OrderByArgType = None,
         _limit: Optional[LimitArgType] = None,
         _group_by: Optional[GroupByArgType] = None,
         _alias=None,
@@ -1199,7 +1200,7 @@ class DbBase(
         _where=None,
         *,
         order_by=None,
-        _order_by=None,
+        _order_by: OrderByArgType = None,
         _limit: Optional[LimitArgType] = None,
         _group_by: Optional[GroupByArgType] = None,
         **where: WhereKwargsType,
@@ -1226,8 +1227,8 @@ class DbBase(
         agg_map_or_str,
         where=None,
         _group_by: Optional[GroupByArgType] = None,
-        _order_by=None,
-        _order=None,
+        _order_by: OrderByArgType = None,
+        _order: Optional[str] = None,  # used only for "simplified" aggregates
         _limit: Optional[LimitArgType] = None,
         **kws,
     ):

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -840,7 +840,7 @@ class DbBase(
 
     def auto_quote(self, key: str):
         return (
-            self.quote_key_or_func(key)
+            self.quote_field_or_func(key)
             if type(key) is AlreadyAliased
             else self.quote_keys(key)
         )

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -223,8 +223,6 @@ class JoinQ(BaseQ):
 
     def resolve_field(self, field: str):
         ret = None
-        if "." in field:
-            return field
         for tab in (self.tab1, self.tab2):
             if field in self.db.get_subq_col_names(tab):
                 if ret is not None:
@@ -849,7 +847,7 @@ class DbBase(
 
     @classmethod
     def quote_field_or_func(cls, key: str) -> str:
-        if "(" in key:
+        if "(" in key or "*" in key:
             return key
         return cls.quote_key(key)
 

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -1085,7 +1085,7 @@ class DbBase(
             table,
             fields=fields,
             dict_where=_where,
-            order_by=order_by or _order_by,
+            _order_by=order_by or _order_by,
             _limit=_limit,
             _group_by=_group_by,
             **where,

--- a/notanorm/base.py
+++ b/notanorm/base.py
@@ -22,6 +22,7 @@ from typing import (
     Optional,
     Callable,
     Union,
+    Iterable,
 )
 
 from .errors import (
@@ -330,6 +331,8 @@ QueryDictType = Dict[str, QueryValueType]
 QueryListType = List[QueryDictType]
 WhereClauseType = Union[QueryDictType, QueryListType]
 WhereKwargsType = Union[QueryValueType, QueryListType]
+LimitArgType = Union[int, Tuple[int, int]]
+GroupByArgType = Union[str, Iterable[str]]
 
 
 class And(QueryListType):
@@ -987,7 +990,7 @@ class DbBase(
         fields: Union[Dict[str, str], List[str]],
         dict_where: WhereClauseType,
         _order_by,
-        _limit,
+        _limit: Optional[LimitArgType],
         _group_by,
         **where: WhereKwargsType,
     ):
@@ -1059,11 +1062,11 @@ class DbBase(
         assert ";" not in order_by_fd
         return "order by " + order_by_fd
 
-    def group_by_query(self, group_by):
+    def group_by_query(self, group_by: GroupByArgType):
         gb = ",".join([group_by] if type(group_by) is str else group_by)
         return f"group by {gb}"
 
-    def limit_query(self, limit):
+    def limit_query(self, limit: LimitArgType):
         try:
             offset, rows = limit
             return f"limit {offset}, {rows}"
@@ -1078,8 +1081,8 @@ class DbBase(
         *,
         order_by=None,
         _order_by=None,
-        _limit=None,
-        _group_by=None,
+        _limit: Optional[LimitArgType] = None,
+        _group_by: Optional[GroupByArgType] = None,
         **where: WhereKwargsType,
     ) -> List[DbRow]:
         """Select from table (or join) using fields (or *) and where (vals can be list or none).
@@ -1116,8 +1119,8 @@ class DbBase(
         *,
         order_by=None,
         _order_by=None,
-        _limit=None,
-        _group_by=None,
+        _limit: Optional[LimitArgType] = None,
+        _group_by: Optional[GroupByArgType] = None,
         _alias=None,
         **where: WhereKwargsType,
     ) -> SubQ:
@@ -1197,8 +1200,8 @@ class DbBase(
         *,
         order_by=None,
         _order_by=None,
-        _limit=None,
-        _group_by=None,
+        _limit: Optional[LimitArgType] = None,
+        _group_by: Optional[GroupByArgType] = None,
         **where: WhereKwargsType,
     ) -> Generator[DbRow, None, None]:
         """Same as select, but returns a generator."""
@@ -1222,10 +1225,10 @@ class DbBase(
         table,
         agg_map_or_str,
         where=None,
-        _group_by=None,
+        _group_by: Optional[GroupByArgType] = None,
         _order_by=None,
         _order=None,
-        _limit=None,
+        _limit: Optional[LimitArgType] = None,
         **kws,
     ):
         if where and kws:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name="notanorm",
-    version="3.3.1",
+    version="3.4.0",
     description="DB wrapper library",
     packages=["notanorm"],
     url="https://github.com/AtakamaLLC/notanorm",

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -1047,6 +1047,10 @@ def test_joinq_model_changes(db_sqlite_notmem):
     with pytest.raises(err.OperationalError):
         db.select(db.join("a", "b", bid="b_id"))
 
+    # explicit table names is always ok
+    db.select(db.join("a", "b", a__bid="b__b_id"), ["a.aid", "b.b_id"])
+
+    # or you can clear the cache
     db.clear_model_cache()
 
     db.select(db.join("a", "b", bid="b_id"))

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -1357,6 +1357,24 @@ def test_raw_fields_group_by(db: DbBase):
     assert all(e.cnt <= l.cnt for e, l in zip(ret, ret[1:]))
 
 
+def test_subq_group_by(db: DbBase):
+    create_group_tabs(db)
+    sub = db.subq(
+        "a", {"cnt": "count(*)", "ver": "max(f3)"}, {}, _group_by=["f1", "f2"]
+    )
+    ret = db.select(sub, ver=2)
+    assert ret == [{"cnt": 2, "ver": 2}, {"cnt": 2, "ver": 2}]
+
+
+def test_group_by_subq(db: DbBase):
+    create_group_tabs(db)
+    sub = db.subq("a", f1=1)
+    ret = db.select(
+        sub, {"cnt": "count(*)", "ver": "max(f3)", "f2": "f2"}, {}, _group_by=["f2"]
+    )
+    assert ret == [{"cnt": 2, "ver": 2, "f2": 1}, {"cnt": 3, "ver": 3, "f2": 2}]
+
+
 def test_agg_group_by(db: DbBase):
     create_group_tabs(db)
 

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -1384,6 +1384,9 @@ def test_agg_group_by(db: DbBase):
         (2, 4): {"sum": 4, "cnt": 2},
     }
 
+    # simple max is easy!
+    assert db.aggregate("a", "max(f3)", f1=1) == 3
+
     with pytest.raises(ValueError):
         # no mix where
         db.aggregate(

--- a/tests/test_notanorm.py
+++ b/tests/test_notanorm.py
@@ -1048,8 +1048,6 @@ def test_joinq_model_changes(db_sqlite_notmem):
 
     assert db.select(db.join("a", "b", bid="bid"))
 
-    file = db.uri.split(":", 1)[1]
-
     # other process has changed things!
     db._conn().execute("drop table b")
     db._conn().execute("create table b (b_id integer primary_key, c_id integer)")


### PR DESCRIPTION
- raw aggregates (you specify field mappings in the select statement)
- generic aggregate function (you specify a mapping, it returns a nice dict)
- count/sum added and use the generic aggregator
- asterisk operator in field maps and field names is not quoted