### PR TITLE
sqlite generator guard fix: nested selects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name="notanorm",
-    version="3.8.0",
+    version="3.8.1",
     description="DB wrapper library",
     packages=["notanorm"],
     url="https://github.com/AtakamaLLC/notanorm",


### PR DESCRIPTION
Nesting `select_gen()`s would cause the generator guard logic to be skipped after the inner block is exited